### PR TITLE
RNMT-2726 Update supported plugins to use support library 28

### DIFF
--- a/src/android/local-notifications-build.gradle
+++ b/src/android/local-notifications-build.gradle
@@ -5,6 +5,6 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.android.support:support-v4:26.+'
-    implementation 'com.android.support:support-core-utils:26.+'
+    implementation 'com.android.support:support-v4:28.0.0'
+    implementation 'com.android.support:support-core-utils:28.0.0'
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Updated supported plugins to use support library 28.

**Breaking changes:** Potential dependency version conflicts
**Breaking changes:** Only compatible with projects that target SDK >= 28

## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->
Closes https://outsystemsrd.atlassian.net/browse/RNMT-2726

<!--- Why is this change required? What problem does it solve? -->
Since we are going to raise the Android target SDK to 28 we also raised the used support library versions to 28.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Feature (change which adds functionality)
    - [x] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [ ] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)
- [ ] Test (non-breaking change that only affects test code)

## Components affected
- [x] Android platform
- [ ] iOS platform
- [ ] JavaScript
- [ ] OutSystems

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Made some exploratory tests with MABS 4.1 / 5.0 and test apps (updating dependencies manually when required).

Performed tests:
 - MABS 5.0 with updated core and support references: OK
 - MABS 5.0 with updated core but without updated support references: OK
 - MABS 4.1 without updated core but with updated support references: NOK

Conclusion:
 - MABS 5.0 seems to work with old and new versions of the supported plugins
 - MABS 4.1 breaks with the newer plugin versions

## Screenshots (if appropriate)
<!--- E.g. before change & after change -->

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly