### PR TITLE
RNMT-3266 Dynamically select dependency version

### DIFF
--- a/src/android/LocalNotification.java
+++ b/src/android/LocalNotification.java
@@ -266,7 +266,7 @@ public class LocalNotification extends CordovaPlugin {
 
         for (int i = 0; i < toasts.length(); i++) {
             JSONObject dict    = toasts.optJSONObject(i);
-            Options options    = new Options(cordova.getContext(), dict);
+            Options options    = new Options(cordova.getActivity(), dict);
             Request request    = new Request(options);
             Notification toast = mgr.schedule(request, TriggerReceiver.class);
 

--- a/src/android/build/localnotification.gradle
+++ b/src/android/build/localnotification.gradle
@@ -27,8 +27,21 @@ if (!project.ext.has('appShortcutBadgerVersion')) {
     ext.appShortcutBadgerVersion = '1.1.19'
 }
 
+String getVersion() {
+  def compileSdkVersion = Integer.parseInt(project.android.compileSdkVersion.split("-")[1])
+  return compileSdkVersion >= 28 ? "28.0.0" : "26.+" 
+}
+
 dependencies {
     implementation "me.leolin:ShortcutBadger:${appShortcutBadgerVersion}@aar"
-    implementation 'com.android.support:support-v4:28.0.0'
-    implementation 'com.android.support:support-core-utils:28.0.0'
 }
+
+// Defer the definition of the dependencies to the end
+// of the "configuration" phase from the app build.gradle file
+// so that we can inquire the proper compile sdk version being used.
+cdvPluginPostBuildExtras.push({
+  dependencies {
+    implementation "com.android.support:support-v4:${getVersion()}"
+    implementation "com.android.support:support-core-utils:${getVersion()}"
+  }
+})

--- a/src/android/notification/Manager.java
+++ b/src/android/notification/Manager.java
@@ -352,7 +352,7 @@ public final class Manager {
                 JSONObject trigger = dict.getJSONObject("trigger");
                 //copy trigger.at to at
                 if (trigger.has("at")) {
-                    dict.put("at", (long) trigger.get("at") / 1000);
+                    dict.put("at", trigger.getLong("at") / 1000);
                 }
                 //copy trigger.every to every
                 if (trigger.has("every")) {


### PR DESCRIPTION
This PR adds the ability for the plugin to pick and choose, in build time, which is the appropriate support library version that must be used depending on the compileSdkVersion (and indirectly the MABS version) in use.

References https://outsystemsrd.atlassian.net/browse/RNMT-3266