### PR TITLE
RNMT-3406 Fix getAll notifications method

### DIFF
--- a/src/android/notification/Manager.java
+++ b/src/android/notification/Manager.java
@@ -45,6 +45,7 @@ import static android.os.Build.VERSION_CODES.M;
 import static android.os.Build.VERSION_CODES.O;
 import static android.support.v4.app.NotificationManagerCompat.IMPORTANCE_DEFAULT;
 import static de.appplant.cordova.plugin.notification.Notification.PREF_KEY_ID;
+import static de.appplant.cordova.plugin.notification.Notification.Type.SCHEDULED;
 import static de.appplant.cordova.plugin.notification.Notification.Type.TRIGGERED;
 
 /**
@@ -220,28 +221,17 @@ public final class Manager {
     }
 
     /**
-     * All local notification IDs for given type.
+     * All local notification ids for given type following the legacy TRIGGERED
      *
      * @param type The notification life cycle type
      */
     public List<Integer> getIdsByType(Notification.Type type) {
+        List<Notification> notifications = getByType(type);
+        List<Integer> ids              = new ArrayList<Integer>();
 
-        if (type == Notification.Type.ALL)
-            return getIds();
-
-        StatusBarNotification[] activeToasts = getActiveNotifications();
-        List<Integer> activeIds              = new ArrayList<Integer>();
-
-        for (StatusBarNotification toast : activeToasts) {
-            activeIds.add(toast.getId());
+        for (Notification toast : notifications) {
+            ids.add(toast.getId());
         }
-
-        if (type == TRIGGERED)
-            return activeIds;
-
-        List<Integer> ids = getIds();
-        ids.removeAll(activeIds);
-
         return ids;
     }
 
@@ -277,13 +267,24 @@ public final class Manager {
      * @param type The notification life cycle type
      */
     private List<Notification> getByType(Notification.Type type) {
-
+        List<Notification> allNotifications = getAll();
         if (type == Notification.Type.ALL)
-            return getAll();
+            return allNotifications;
 
-        List<Integer> ids = getIdsByType(type);
+        List<Notification> scheduled = new ArrayList<>();
 
-        return getByIds(ids);
+        for (Notification toast : allNotifications) {
+            if(toast.isScheduled()){
+                scheduled.add(toast);
+            }
+        }
+
+        if (type == SCHEDULED)
+            return scheduled;
+
+        allNotifications.removeAll(scheduled);
+
+        return allNotifications;
     }
 
     /**

--- a/src/android/notification/Notification.java
+++ b/src/android/notification/Notification.java
@@ -29,7 +29,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.net.Uri;
-import android.service.notification.StatusBarNotification;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.util.ArraySet;
 import android.support.v4.util.Pair;
@@ -160,20 +159,32 @@ public final class Notification {
     }
 
     /**
-     * Notification type can be one of triggered or scheduled.
+     * Previous implementation of getType method. A notification is of type triggered if it was already triggered and is not a repeating notification
      */
     public Type getType() {
-        Manager mgr                    = Manager.getInstance(context);
-        StatusBarNotification[] toasts = mgr.getActiveNotifications();
-        int id                         = getId();
+        return isScheduled() ? Type.SCHEDULED : Type.TRIGGERED;
+    }
 
-        for (StatusBarNotification toast : toasts) {
-            if (toast.getId() == id) {
-                return Type.TRIGGERED;
-            }
-        }
+    /**
+     * If the notification is scheduled.
+     */
+    public boolean isScheduled() {
+        return isRepeating() || !wasInThePast();
+    }
 
-        return Type.SCHEDULED;
+    /**
+     * If the notification was in the past.
+     */
+    public boolean wasInThePast() {
+        return new Date().after(getTriggerDate());
+    }
+
+    /**
+     * Trigger date.
+     */
+    public Date getTriggerDate() {
+        Long dateTime = options.getTrigger().optLong("at", 0);
+        return new Date(dateTime);
     }
 
     /**


### PR DESCRIPTION
## Android Only
With the merge of the upstream, the concept of the type of TRIGGERED notification was changed. According to the upstream, a TRIGGERED notification is a notification that is active in the Notification tray.

This behaviour was reverted to our previous definition of TRIGGERED -> a triggered notification is a notification that has a date in the past and is not recurrent.


References https://outsystemsrd.atlassian.net/browse/RNMT-3406