### PR TITLE
RNMT-3406 Fix diamond operator

### DIFF
--- a/src/android/notification/Manager.java
+++ b/src/android/notification/Manager.java
@@ -271,7 +271,7 @@ public final class Manager {
         if (type == Notification.Type.ALL)
             return allNotifications;
 
-        List<Notification> scheduled = new ArrayList<>();
+        List<Notification> scheduled = new ArrayList<Notification>();
 
         for (Notification toast : allNotifications) {
             if(toast.isScheduled()){


### PR DESCRIPTION
The last version was using a diamond operator in Java, that is not compatible with MABS version 3 and 4.

This commit fixes it.