### PR TITLE
RNMT-3407 [Local Notifications] Recurrence by second doesn't work

### DIFF
--- a/src/ios/APPNotificationOptions.m
+++ b/src/ios/APPNotificationOptions.m
@@ -466,6 +466,9 @@ static NSInteger WEEKDAYS[8] = { 0, 2, 3, 4, 5, 6, 7, 1 };
     NSString* interval = [self valueForTriggerOption:@"every"];
     NSCalendarUnit units = NSCalendarUnitYear|NSCalendarUnitMonth|NSCalendarUnitDay|NSCalendarUnitHour|NSCalendarUnitMinute|NSCalendarUnitSecond;
 
+    if ([interval isEqualToString:@"second"])
+        return NSCalendarUnitSecond;
+
     if ([interval isEqualToString:@"minute"])
         return NSCalendarUnitSecond;
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fixes recurrence by second in iOS.

## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->
Fixes https://outsystemsrd.atlassian.net/browse/RNMT-3407

<!--- Why is this change required? What problem does it solve? -->
Recurrence must be at least 60 seconds. Therefore setting recurrence as "second" sends a notification every 60 seconds, similarly to the "minute" setting.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [x] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)
- [ ] Test (non-breaking change that only affects test code)

## Components affected
- [ ] Android platform
- [x] iOS platform
- [ ] JavaScript
- [ ] OutSystems

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Manual tests were performed.

## Screenshots (if appropriate)
<!--- E.g. before change & after change -->

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly