### PR TITLE
RMET-7 Fix scheduling notification with empty date field sets notification to default Date object

### DIFF
--- a/www/local-notification.js
+++ b/www/local-notification.js
@@ -709,6 +709,11 @@ exports._convertTrigger = function (options) {
     var trigger  = options.trigger || {},
         date     = this._getValueFor(trigger, 'at', 'firstAt', 'date');
 
+    if(date === null){
+        date = new Date(Date.now());
+        date.setSeconds(date.getSeconds() + 5);
+    }
+
     var dateToNum = function (date) {
         var num = typeof date == 'object' ? date.getTime() : (typeof date == 'string' ? Date.parse(date) : date);
         if(num.length === 10){


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
When passing a null data through the scheduler each platform will create a default date object, in case of android for example dates start in the year 1900, to avoid that when a null date is passed the date is set automatically to the current date plus 5 seconds
## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->
Fixes issue: https://outsystemsrd.atlassian.net/browse/RMET-7
<!--- Why is this change required? What problem does it solve? -->

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [x] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [ ] Android platform
- [ ] iOS platform
- [x] JavaScript
- [ ] OutSystems

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

## Screenshots (if appropriate)
<!--- E.g. before change & after change -->

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly