### PR TITLE
RMET-321 LocalNotifications Null Date allowed

### DIFF
--- a/www/local-notification.js
+++ b/www/local-notification.js
@@ -709,10 +709,6 @@ exports._convertTrigger = function (options) {
     var trigger  = options.trigger || {},
         date     = this._getValueFor(trigger, 'at', 'firstAt', 'date');
 
-    if(date === null){
-        date = new Date(Date.now());
-        date.setSeconds(date.getSeconds() + 5);
-    }
 
     var dateToNum = function (date) {
         var num = typeof date == 'object' ? date.getTime() : (typeof date == 'string' ? Date.parse(date) : date);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The previous fix addresses the issue raised by the null date by comparing the date inserted with the time that exists now, however there was a leftover defective code that interferes with that behaviour
## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->

<!--- Why is this change required? What problem does it solve? -->

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [x] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [ ] Android platform
- [ ] iOS platform
- [x] JavaScript
- [ ] OutSystems

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

## Screenshots (if appropriate)
<!--- E.g. before change & after change -->

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [ ] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly