### PR TITLE
RMET-220 Local notification - Interval value is not updated with "None" value on Android devices

### DIFF
--- a/src/android/LocalNotification.java
+++ b/src/android/LocalNotification.java
@@ -299,6 +299,7 @@ public class LocalNotification extends CordovaPlugin {
                         trigger.put("every", update.get("every"));
                     }
                     update.put("trigger", trigger);
+                    Log.e("JSON put Exception", "Exception thrown trying to put trigger information into the JSON object holding the update information.");
                 }catch (JSONException e) {
                     e.printStackTrace();
                 }

--- a/src/android/LocalNotification.java
+++ b/src/android/LocalNotification.java
@@ -290,6 +290,20 @@ public class LocalNotification extends CordovaPlugin {
 
         for (int i = 0; i < updates.length(); i++) {
             JSONObject update  = updates.optJSONObject(i);
+
+            if(!update.has("trigger")){
+                JSONObject trigger = new JSONObject();
+                try{
+                    trigger.put("type", "calendar");
+                    if(!update.get("every").equals("")){
+                        trigger.put("every", update.get("every"));
+                    }
+                    update.put("trigger", trigger);
+                }catch (JSONException e) {
+                    e.printStackTrace();
+                }
+            }
+
             int id             = update.optInt("id", 0);
             Notification toast = mgr.update(id, update, TriggerReceiver.class);
 

--- a/src/android/LocalNotification.java
+++ b/src/android/LocalNotification.java
@@ -299,9 +299,9 @@ public class LocalNotification extends CordovaPlugin {
                         trigger.put("every", update.get("every"));
                     }
                     update.put("trigger", trigger);
-                    Log.e("JSON put Exception", "Exception thrown trying to put trigger information into the JSON object holding the update information.");
                 }catch (JSONException e) {
                     e.printStackTrace();
+                    Log.e("JSON put Exception", "Exception thrown trying to put trigger information into the JSON object holding the update information.");
                 }
             }
 


### PR DESCRIPTION
## Description
Updated recurrence now showing in notification list correctly

## Context
Fixes https://outsystemsrd.atlassian.net/browse/RMET-220

<!--- Why is this change required? What problem does it solve? -->
Changed update notification logic in native code (Android) so that when updating a notification and changing its recurrence, this new change appears in the notification info in the Get All Notifications screen.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [x] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [x] Android platform
- [ ] iOS platform
- [ ] JavaScript
- [ ] OutSystems

## Tests
Executed tests with P0 priority from the Test Plan

## Screenshots (if appropriate)
<!--- E.g. before change & after change -->

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly