### PR TITLE
RMET-822 Local Notifications Plugin - Android 12 compatibility changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ ChangeLog
 
 Please also read the [Upgrade Guide](https://github.com/katzer/cordova-plugin-local-notifications/wiki/Upgrade-Guide) for more information.
 
+#### Unreleased
+- Changes required for Android 12 - Include SCHEDULE_EXACT_ALARM permission and specify mutability on PendingIntents (https://outsystemsrd.atlassian.net/browse/RMET-822)
+
 #### Version 0.8.5 (22.05.2017)
 - iOS 10
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -135,6 +135,7 @@
         <config-file target="AndroidManifest.xml" parent="/manifest">
             <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
             <uses-permission android:name="android.permission.WAKE_LOCK" />
+            <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
         </config-file>
 
         <source-file

--- a/src/android/notification/Builder.java
+++ b/src/android/notification/Builder.java
@@ -38,9 +38,7 @@ import java.util.Random;
 import de.appplant.cordova.plugin.notification.action.Action;
 
 import static android.app.PendingIntent.FLAG_UPDATE_CURRENT;
-import static android.app.PendingIntent.FLAG_MUTABLE;
 import static android.os.Build.VERSION.SDK_INT;
-import static android.os.Build.VERSION_CODES.S;
 import static de.appplant.cordova.plugin.notification.Notification.EXTRA_UPDATE;
 
 /**
@@ -328,9 +326,9 @@ public final class Builder {
 
         PendingIntent deleteIntent;
 
-        if(SDK_INT >= S){
+        if(SDK_INT >= 31){
             deleteIntent = PendingIntent.getBroadcast(
-                    context, reqCode, intent, FLAG_UPDATE_CURRENT | PendingIntent.FLAG_MUTABLE);
+                    context, reqCode, intent, FLAG_UPDATE_CURRENT | 33554432);
         }
         else{
             deleteIntent = PendingIntent.getBroadcast(
@@ -365,9 +363,9 @@ public final class Builder {
 
         PendingIntent contentIntent;
 
-        if(SDK_INT >= S){
+        if(SDK_INT >= 31){
             contentIntent = PendingIntent.getService(
-                    context, reqCode, intent, FLAG_UPDATE_CURRENT | PendingIntent.FLAG_MUTABLE);
+                    context, reqCode, intent, FLAG_UPDATE_CURRENT | 33554432);
         }
         else{
             contentIntent = PendingIntent.getService(
@@ -423,9 +421,9 @@ public final class Builder {
 
         PendingIntent toReturn;
 
-        if(SDK_INT >= S){
+        if(SDK_INT >= 31){
             toReturn = PendingIntent.getService(
-                    context, reqCode, intent, FLAG_UPDATE_CURRENT | PendingIntent.FLAG_MUTABLE);
+                    context, reqCode, intent, FLAG_UPDATE_CURRENT | 33554432);
         }
         else{
             toReturn = PendingIntent.getService(

--- a/src/android/notification/Builder.java
+++ b/src/android/notification/Builder.java
@@ -27,9 +27,9 @@ import android.content.Intent;
 import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.Bundle;
-import android.support.v4.app.NotificationCompat;
-import android.support.v4.app.NotificationCompat.MessagingStyle.Message;
-import android.support.v4.media.app.NotificationCompat.MediaStyle;
+import androidx.core.app.NotificationCompat;
+import androidx.core.app.NotificationCompat.MessagingStyle.Message;
+import androidx.media.app.NotificationCompat.MediaStyle;
 import android.support.v4.media.session.MediaSessionCompat;
 
 import java.util.List;
@@ -38,6 +38,9 @@ import java.util.Random;
 import de.appplant.cordova.plugin.notification.action.Action;
 
 import static android.app.PendingIntent.FLAG_UPDATE_CURRENT;
+import static android.app.PendingIntent.FLAG_MUTABLE;
+import static android.os.Build.VERSION.SDK_INT;
+import static android.os.Build.VERSION_CODES.S;
 import static de.appplant.cordova.plugin.notification.Notification.EXTRA_UPDATE;
 
 /**
@@ -323,8 +326,16 @@ public final class Builder {
 
         int reqCode = random.nextInt();
 
-        PendingIntent deleteIntent = PendingIntent.getBroadcast(
-                context, reqCode, intent, FLAG_UPDATE_CURRENT);
+        PendingIntent deleteIntent;
+
+        if(SDK_INT >= S){
+            deleteIntent = PendingIntent.getBroadcast(
+                    context, reqCode, intent, FLAG_UPDATE_CURRENT | PendingIntent.FLAG_MUTABLE);
+        }
+        else{
+            deleteIntent = PendingIntent.getBroadcast(
+                    context, reqCode, intent, FLAG_UPDATE_CURRENT);
+        }
 
         builder.setDeleteIntent(deleteIntent);
     }
@@ -352,8 +363,16 @@ public final class Builder {
 
         int reqCode = random.nextInt();
 
-        PendingIntent contentIntent = PendingIntent.getService(
-                context, reqCode, intent, FLAG_UPDATE_CURRENT);
+        PendingIntent contentIntent;
+
+        if(SDK_INT >= S){
+            contentIntent = PendingIntent.getService(
+                    context, reqCode, intent, FLAG_UPDATE_CURRENT | PendingIntent.FLAG_MUTABLE);
+        }
+        else{
+            contentIntent = PendingIntent.getService(
+                    context, reqCode, intent, FLAG_UPDATE_CURRENT);
+        }
 
         builder.setContentIntent(contentIntent);
     }
@@ -402,8 +421,18 @@ public final class Builder {
 
         int reqCode = random.nextInt();
 
-        return PendingIntent.getService(
-                context, reqCode, intent, FLAG_UPDATE_CURRENT);
+        PendingIntent toReturn;
+
+        if(SDK_INT >= S){
+            toReturn = PendingIntent.getService(
+                    context, reqCode, intent, FLAG_UPDATE_CURRENT | PendingIntent.FLAG_MUTABLE);
+        }
+        else{
+            toReturn = PendingIntent.getService(
+                    context, reqCode, intent, FLAG_UPDATE_CURRENT);
+        }
+
+        return toReturn;
     }
 
     /**

--- a/src/android/notification/Notification.java
+++ b/src/android/notification/Notification.java
@@ -48,10 +48,8 @@ import java.util.Set;
 import static android.app.AlarmManager.RTC;
 import static android.app.AlarmManager.RTC_WAKEUP;
 import static android.app.PendingIntent.FLAG_CANCEL_CURRENT;
-import static android.app.PendingIntent.FLAG_MUTABLE;
 import static android.os.Build.VERSION.SDK_INT;
 import static android.os.Build.VERSION_CODES.M;
-import static android.os.Build.VERSION_CODES.S;
 import static androidx.core.app.NotificationCompat.PRIORITY_HIGH;
 import static androidx.core.app.NotificationCompat.PRIORITY_MAX;
 import static androidx.core.app.NotificationCompat.PRIORITY_MIN;
@@ -243,9 +241,9 @@ public final class Notification {
 
             PendingIntent pi;
 
-            if(SDK_INT >= S){
+            if(SDK_INT >= 31){
                 pi = PendingIntent.getBroadcast(
-                        context, 0, intent, FLAG_CANCEL_CURRENT | PendingIntent.FLAG_MUTABLE);
+                        context, 0, intent, FLAG_CANCEL_CURRENT | 33554432);
             }
             else{
                 pi = PendingIntent.getBroadcast(
@@ -338,9 +336,9 @@ public final class Notification {
 
             PendingIntent pi;
 
-            if(SDK_INT >= S){
+            if(SDK_INT >= 31){
                 pi = PendingIntent.getBroadcast(
-                        context, 0, intent, PendingIntent.FLAG_MUTABLE);
+                        context, 0, intent, 33554432);
             }
             else{
                 pi = PendingIntent.getBroadcast(

--- a/src/android/notification/Notification.java
+++ b/src/android/notification/Notification.java
@@ -29,9 +29,10 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.net.Uri;
-import android.support.v4.app.NotificationCompat;
-import android.support.v4.util.ArraySet;
-import android.support.v4.util.Pair;
+import androidx.core.app.NotificationCompat;
+import androidx.collection.ArraySet;
+import androidx.core.util.Pair;
+
 import android.util.Log;
 import android.util.SparseArray;
 
@@ -47,11 +48,13 @@ import java.util.Set;
 import static android.app.AlarmManager.RTC;
 import static android.app.AlarmManager.RTC_WAKEUP;
 import static android.app.PendingIntent.FLAG_CANCEL_CURRENT;
+import static android.app.PendingIntent.FLAG_MUTABLE;
 import static android.os.Build.VERSION.SDK_INT;
 import static android.os.Build.VERSION_CODES.M;
-import static android.support.v4.app.NotificationCompat.PRIORITY_HIGH;
-import static android.support.v4.app.NotificationCompat.PRIORITY_MAX;
-import static android.support.v4.app.NotificationCompat.PRIORITY_MIN;
+import static android.os.Build.VERSION_CODES.S;
+import static androidx.core.app.NotificationCompat.PRIORITY_HIGH;
+import static androidx.core.app.NotificationCompat.PRIORITY_MAX;
+import static androidx.core.app.NotificationCompat.PRIORITY_MIN;
 
 /**
  * Wrapper class around OS notification class. Handles basic operations
@@ -238,8 +241,16 @@ public final class Notification {
             if (!date.after(new Date()) && trigger(intent, receiver))
                 continue;
 
-            PendingIntent pi = PendingIntent.getBroadcast(
-                    context, 0, intent, FLAG_CANCEL_CURRENT);
+            PendingIntent pi;
+
+            if(SDK_INT >= S){
+                pi = PendingIntent.getBroadcast(
+                        context, 0, intent, FLAG_CANCEL_CURRENT | PendingIntent.FLAG_MUTABLE);
+            }
+            else{
+                pi = PendingIntent.getBroadcast(
+                        context, 0, intent, FLAG_CANCEL_CURRENT);
+            }
 
             try {
                 switch (options.getPrio()) {
@@ -325,8 +336,16 @@ public final class Notification {
         for (String action : actions) {
             Intent intent = new Intent(action);
 
-            PendingIntent pi = PendingIntent.getBroadcast(
-                    context, 0, intent, 0);
+            PendingIntent pi;
+
+            if(SDK_INT >= S){
+                pi = PendingIntent.getBroadcast(
+                        context, 0, intent, PendingIntent.FLAG_MUTABLE);
+            }
+            else{
+                pi = PendingIntent.getBroadcast(
+                        context, 0, intent, 0);
+            }
 
             if (pi != null) {
                 getAlarmMgr().cancel(pi);


### PR DESCRIPTION
## Description
Added the SCHEDULE_EXACT_ALARM permission to the plugin.xml to be added in the AndroidManifest, as it is now necessary for Android 12 (API 31).

Added mutability flag on PendingIntent objects. As we schedule notifications with the AlarmManager, this flag should be FLAG_MUTABLE and not IMMUTABLE (https://developer.android.com/about/versions/12/behavior-changes-12#pending-intent-mutability). Also, FLAG_MUTABLE was the default value for PendingIntent up until API 30. Changed Build.java and Notification.java classes with this. 

## Context
<!--- Why is this change required? What problem does it solve? -->
Android 12 introduces some changes, namely: 
- To use exact alarms, as we do for the notifications, the SCHEDULE_EXACT_ALARM permission must be present in the AndroidManifest.xml
- PendingIntents must specify their mutability (IMMUTABLE or MUTABLE).


## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [x] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [x] Android platform
- [ ] iOS platform
- [ ] JavaScript
- [ ] OutSystems

## Tests
Tested locally in Android Studio targetting API 31 and running on Android 12. Before making the changes, the app would crash because the PendingIntent objects did not specify their mutability. Also, without the SCHEDULE_EXACT_ALARM permission, the notifications did not show.

MABS 7.1 build working after latest commit on PR.

## Screenshots (if appropriate)
<!--- E.g. before change & after change -->
![image](https://user-images.githubusercontent.com/27646996/129781235-15942019-df4b-410b-b1bf-469af36b4caa.png)


## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly