### PR TITLE
RMET-822 Local Notifications Plugin - Fix badge dependency to use different release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Please also read the [Upgrade Guide](https://github.com/katzer/cordova-plugin-lo
 
 #### Unreleased
 - Changes required for Android 12 - Include SCHEDULE_EXACT_ALARM permission and specify mutability on PendingIntents (https://outsystemsrd.atlassian.net/browse/RMET-822)
+- Changes required for Andorid 12 - Change dependecy to cordova-plugin-badge so that MABS 8 build works (because of a gradle file) (https://outsystemsrd.atlassian.net/browse/RMET-822)
 
 #### Version 0.8.5 (22.05.2017)
 - iOS 10

--- a/plugin.xml
+++ b/plugin.xml
@@ -50,7 +50,7 @@
 
     <!-- dependencies -->
     <dependency id="cordova-plugin-device" />
-    <dependency id="cordova-plugin-badge" version=">=0.8.5" />
+    <dependency id="cordova-plugin-badge" url="https://github.com/OutSystems/cordova-plugin-badge.git#master" />
 
     <!-- js -->
     <js-module src="www/local-notification.js" name="LocalNotification">


### PR DESCRIPTION
## Description
Changed the dependency to cordova-plugin-badge to use a most recent release. There was a problem in the MABS 8 (template) build because of the badge.gradle file from that dependency.

**Important:** We are using the master branch instead of a release tag because as of now we do not have access to the outsystems/cordova-plugin-badge repository. Once we do, we should create a new outsystems branch, raise the plugin's verison to 0.8.8-OS, create a new release tag and use it in this dependency.

## Context
<!--- Why is this change required? What problem does it solve? -->
MABS 8 (template) was failing because the badge.gradle file from version 0.8.5 includes a dependency using 'compile' instead of 'implementation'.


## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [x] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [x] Android platform
- [ ] iOS platform
- [ ] JavaScript
- [ ] OutSystems

## Tests
MABS 8 build (with template) now working and plugin working.

## Screenshots (if appropriate)
<!--- E.g. before change & after change -->

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly