### PR TITLE
RMET-822 Local Notifications Plugin - Remove notification trampolin for Android 12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Please also read the [Upgrade Guide](https://github.com/katzer/cordova-plugin-lo
 #### Unreleased
 - Changes required for Android 12 - Include SCHEDULE_EXACT_ALARM permission and specify mutability on PendingIntents (https://outsystemsrd.atlassian.net/browse/RMET-822)
 - Changes required for Andorid 12 - Change dependecy to cordova-plugin-badge so that MABS 8 build works (because of a gradle file) (https://outsystemsrd.atlassian.net/browse/RMET-822)
+- Changes required for Andorid 12 - Do not use notification trampolines for Android >= 12 (https://outsystemsrd.atlassian.net/browse/RMET-822)
+
 
 #### Version 0.8.5 (22.05.2017)
 - iOS 10

--- a/src/android/notification/Builder.java
+++ b/src/android/notification/Builder.java
@@ -41,6 +41,8 @@ import static android.app.PendingIntent.FLAG_UPDATE_CURRENT;
 import static android.os.Build.VERSION.SDK_INT;
 import static de.appplant.cordova.plugin.notification.Notification.EXTRA_UPDATE;
 
+import com.outsystems.rd.LocalNotificationsSampleApp.MainActivity;
+
 /**
  * Builder class for local notifications. Build fully configured local
  * notification specified by JSON object passed from JS side.
@@ -364,8 +366,9 @@ public final class Builder {
         PendingIntent contentIntent;
 
         if(SDK_INT >= 31){
-            contentIntent = PendingIntent.getService(
-                    context, reqCode, intent, FLAG_UPDATE_CURRENT | 33554432);
+            Intent resultIntent = new Intent(context, MainActivity.class);
+            contentIntent = PendingIntent.getActivity(
+                    context, reqCode, resultIntent, PendingIntent.FLAG_UPDATE_CURRENT | 33554432);
         }
         else{
             contentIntent = PendingIntent.getService(


### PR DESCRIPTION
## Description
Removed notification trampoline on Android >= 12. This was being used in the `PendingIntent.getService` method, in the applyContentReceiver method. We were delegating the click on a notification to a Service component, and in Android 12 we cannot do this anymore. We have to define the Activity we wish to open right when we define the PendingIntent.

## Context
<!--- Why is this change required? What problem does it solve? -->
We were delegating the click on a notification to a Service component, and in Android 12 we cannot do this anymore. So we need to create a PendingIntent in a different way for the notification to be clickable in Android >= 12.


## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [x] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [x] Android platform
- [ ] iOS platform
- [ ] JavaScript
- [ ] OutSystems

## Tests
Tested locally with the NativeShell Template for MABS 8 and also builded the Sample App with MABS 7.1. Tested both the distributions.

## Screenshots (if appropriate)
<!--- E.g. before change & after change -->

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly