### PR TITLE
RMET-822 Local Notifications Plugin - Update dependency to use tag instead of branch

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -50,7 +50,7 @@
 
     <!-- dependencies -->
     <dependency id="cordova-plugin-device" />
-    <dependency id="cordova-plugin-badge" url="https://github.com/OutSystems/cordova-plugin-badge.git#master" />
+    <dependency id="cordova-plugin-badge" url="https://github.com/OutSystems/cordova-plugin-badge.git#0.8.8-OS" />
 
     <!-- js -->
     <js-module src="www/local-notification.js" name="LocalNotification">


### PR DESCRIPTION
## Description
We should use a tag instead of a branch. Couldn't do this sooner because we were waiting for access to the repository (outsystems/cordova-plugin-badge).

## Context
<!--- Why is this change required? What problem does it solve? -->
This tag has the change we need in the badge.gradle file from the dependency.


## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [ ] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [x] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [x] Android platform
- [ ] iOS platform
- [ ] JavaScript
- [ ] OutSystems

## Tests

## Screenshots (if appropriate)
<!--- E.g. before change & after change -->

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly