### PR TITLE
RMET 1007 LocalNotifications Plugin - Use Activity to handle notification clicks instead of a Service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ ChangeLog
 
 Please also read the [Upgrade Guide](https://github.com/katzer/cordova-plugin-local-notifications/wiki/Upgrade-Guide) for more information.
 
+
+#### Unreleased 0.9.7
+- Fix required for Android 12 - Use Activity instead of Service to handle notification clicks (https://outsystemsrd.atlassian.net/browse/RMET-1007)
+
 #### Unreleased 0.9.6
 - Changes required for Android 12 - Include SCHEDULE_EXACT_ALARM permission and specify mutability on PendingIntents (https://outsystemsrd.atlassian.net/browse/RMET-822)
 - Changes required for Andorid 12 - Change dependecy to cordova-plugin-badge so that MABS 8 build works (because of a gradle file) (https://outsystemsrd.atlassian.net/browse/RMET-822)

--- a/plugin.xml
+++ b/plugin.xml
@@ -130,6 +130,11 @@
                     <action android:name="android.intent.action.BOOT_COMPLETED" />
                 </intent-filter>
             </receiver>
+            <activity
+                android:exported="false"
+                android:launchMode="singleTask"
+                android:name="de.appplant.cordova.plugin.localnotification.ClickActivity"
+                android:theme="@android:style/Theme.NoDisplay" />
         </config-file>
 
         <config-file target="AndroidManifest.xml" parent="/manifest">
@@ -155,6 +160,10 @@
             target-dir="src/de/appplant/cordova/plugin/localnotification" />
 
         <source-file
+            src="src/android/ClickActivity.java"
+            target-dir="src/de/appplant/cordova/plugin/localnotification" />    
+
+        <source-file
             src="src/android/ClearReceiver.java"
             target-dir="src/de/appplant/cordova/plugin/localnotification" />
 
@@ -176,6 +185,10 @@
 
         <source-file
             src="src/android/notification/receiver/AbstractClickReceiver.java"
+            target-dir="src/de/appplant/cordova/plugin/notification/receiver" />
+
+        <source-file
+            src="src/android/notification/receiver/AbstractClickActivity.java"
             target-dir="src/de/appplant/cordova/plugin/notification/receiver" />
 
         <source-file

--- a/src/android/ClickActivity.java
+++ b/src/android/ClickActivity.java
@@ -1,0 +1,78 @@
+package de.appplant.cordova.plugin.localnotification;
+
+import static de.appplant.cordova.plugin.localnotification.LocalNotification.fireEvent;
+import static de.appplant.cordova.plugin.notification.Options.EXTRA_LAUNCH;
+import static de.appplant.cordova.plugin.notification.Request.EXTRA_LAST;
+
+import android.os.Bundle;
+
+import androidx.core.app.RemoteInput;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import de.appplant.cordova.plugin.notification.Notification;
+import de.appplant.cordova.plugin.notification.receiver.AbstractClickActivity;
+
+public class ClickActivity extends AbstractClickActivity {
+
+
+    @Override
+    public void onClick(Notification notification) {
+        String action   = getAction();
+        JSONObject data = new JSONObject();
+
+        setTextInput(action, data);
+        launchAppIf();
+
+        fireEvent(action, notification, data);
+
+        if (notification.getOptions().isSticky())
+            return;
+
+        if (isLast()) {
+            notification.cancel();
+        } else {
+            notification.clear();
+        }
+    }
+
+    /**
+     * Set the text if any remote input is given.
+     *
+     * @param action The action where to look for.
+     * @param data   The object to extend.
+     */
+    private void setTextInput(String action, JSONObject data) {
+        Bundle input = RemoteInput.getResultsFromIntent(getIntent());
+
+        if (input == null)
+            return;
+
+        try {
+            data.put("text", input.getCharSequence(action));
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Launch app if requested by user.
+     */
+    private void launchAppIf() {
+        boolean doLaunch = getIntent().getBooleanExtra(EXTRA_LAUNCH, true);
+
+        if (!doLaunch)
+            return;
+
+        launchApp();
+    }
+
+    /**
+     * If the notification was the last scheduled one by request.
+     */
+    private boolean isLast() {
+        return getIntent().getBooleanExtra(EXTRA_LAST, false);
+    }
+
+}

--- a/src/android/notification/Builder.java
+++ b/src/android/notification/Builder.java
@@ -35,13 +35,12 @@ import android.support.v4.media.session.MediaSessionCompat;
 import java.util.List;
 import java.util.Random;
 
+import de.appplant.cordova.plugin.localnotification.ClickActivity;
 import de.appplant.cordova.plugin.notification.action.Action;
 
 import static android.app.PendingIntent.FLAG_UPDATE_CURRENT;
 import static android.os.Build.VERSION.SDK_INT;
 import static de.appplant.cordova.plugin.notification.Notification.EXTRA_UPDATE;
-
-import com.outsystems.rd.LocalNotificationsSampleApp.MainActivity;
 
 /**
  * Builder class for local notifications. Build fully configured local
@@ -351,28 +350,30 @@ public final class Builder {
         if (clickActivity == null)
             return;
 
-        Intent intent = new Intent(context, clickActivity)
-                .putExtra(Notification.EXTRA_ID, options.getId())
-                .putExtra(Action.EXTRA_ID, Action.CLICK_ACTION_ID)
-                .putExtra(Options.EXTRA_LAUNCH, options.isLaunchingApp())
-                .setFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
-
-        if (extras != null) {
-            intent.putExtras(extras);
-        }
-
         int reqCode = random.nextInt();
 
         PendingIntent contentIntent;
 
+        Bundle myBundle = new Bundle();
+        myBundle.putInt(Notification.EXTRA_ID, options.getId());
+        myBundle.putString(Action.EXTRA_ID, Action.CLICK_ACTION_ID);
+        myBundle.putBoolean(Options.EXTRA_LAUNCH, options.isLaunchingApp());
+
+        Intent myIntent = new Intent(context, ClickActivity.class)
+                .putExtras(myBundle)
+                .setFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
+
+        if (extras != null) {
+            myIntent.putExtras(extras);
+        }
+
         if(SDK_INT >= 31){
-            Intent resultIntent = new Intent(context, MainActivity.class);
             contentIntent = PendingIntent.getActivity(
-                    context, reqCode, resultIntent, PendingIntent.FLAG_UPDATE_CURRENT | 33554432);
+                    context, reqCode, myIntent, PendingIntent.FLAG_UPDATE_CURRENT | 33554432);
         }
         else{
-            contentIntent = PendingIntent.getService(
-                    context, reqCode, intent, FLAG_UPDATE_CURRENT);
+            contentIntent = PendingIntent.getActivity(
+                    context, reqCode, myIntent, PendingIntent.FLAG_UPDATE_CURRENT);
         }
 
         builder.setContentIntent(contentIntent);

--- a/src/android/notification/receiver/AbstractClickActivity.java
+++ b/src/android/notification/receiver/AbstractClickActivity.java
@@ -1,0 +1,74 @@
+package de.appplant.cordova.plugin.notification.receiver;
+
+import static android.content.Intent.FLAG_ACTIVITY_REORDER_TO_FRONT;
+import static android.content.Intent.FLAG_ACTIVITY_SINGLE_TOP;
+import static android.content.Intent.FLAG_ACTIVITY_CLEAR_TOP;
+import static android.content.Intent.FLAG_ACTIVITY_NEW_TASK;
+import static de.appplant.cordova.plugin.notification.action.Action.CLICK_ACTION_ID;
+import static de.appplant.cordova.plugin.notification.action.Action.EXTRA_ID;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+
+import androidx.annotation.Nullable;
+
+import de.appplant.cordova.plugin.notification.Manager;
+import de.appplant.cordova.plugin.notification.Notification;
+
+abstract public class AbstractClickActivity extends Activity {
+
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+
+        super.onCreate(savedInstanceState);
+
+        Intent newIntent = getIntent();
+
+        Bundle newBundle = newIntent.getExtras();
+
+        Context context = getApplicationContext();
+
+        if (newBundle == null)
+            return;
+
+        int notificationId = newBundle.getInt(Notification.EXTRA_ID);
+        Notification notification = Manager.getInstance(context).get(notificationId);
+
+        if (notification == null)
+            return;
+
+        onClick(notification);
+        finish();
+    }
+
+    abstract public void onClick (Notification notification);
+
+    /**
+     * The invoked action.
+     */
+    protected String getAction() {
+        return getIntent().getExtras().getString(EXTRA_ID, CLICK_ACTION_ID);
+    }
+
+    /**
+     * Launch main intent from package.
+     */
+    protected void launchApp() {
+        Context context = getApplicationContext();
+        String pkgName  = context.getPackageName();
+
+        Intent intent = context
+                .getPackageManager()
+                .getLaunchIntentForPackage(pkgName);
+
+        if (intent == null)
+            return;
+
+        intent.addFlags(FLAG_ACTIVITY_REORDER_TO_FRONT | FLAG_ACTIVITY_SINGLE_TOP | FLAG_ACTIVITY_CLEAR_TOP | FLAG_ACTIVITY_NEW_TASK);
+        context.startActivity(intent);
+    }
+
+}


### PR DESCRIPTION
## Description

- This PR fixes the behaviour of clicking on a notification and triggering the NotificationClicked event to be handled in OutSystems for Android 12. 
- This wasn't working because we were using a Service to handle the notification clicks, and as of Android 12 (API 31) the Android system blocks the usage of Services or Broadcast Receivers to handle notification clicks (this behaviour is known as notification trampolins).
- So now we use an Activity (ClickActivity) to handle the notification clicks instead of the ClickReceiver, which is a Service.
- As this new approach of using an Activity also works for all other Android versions, and it is actually the way that Google recommends of dealing with notification clicks, we'll use it in all Android versions.

## Context
<!--- Why is this change required? What problem does it solve? -->
References: https://outsystemsrd.atlassian.net/browse/RMET-1007


## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [x] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [x] Android platform
- [ ] iOS platform
- [ ] JavaScript
- [ ] OutSystems

## Tests
MABS 7.1 and MABS 8 builds working. Plugin working on both versions for Android 12 and all other Android versions we support.

## Screenshots (if appropriate)
<!--- E.g. before change & after change -->

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly