### PR TITLE
RMET-1833 Fixed permission request for API >= 33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ ChangeLog
 
 Please also read the [Upgrade Guide](https://github.com/katzer/cordova-plugin-local-notifications/wiki/Upgrade-Guide) for more information.
 
+#### Unreleased
+- Fix required for Android 13 regarding notification permissions (https://outsystemsrd.atlassian.net/browse/RMET-1833)
+
 #### Version 0.9.8 (04.11.2021)
 - New plugin release to include metadata tag in Extensibility Configurations in the OS wrapper
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -141,6 +141,8 @@
             <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
             <uses-permission android:name="android.permission.WAKE_LOCK" />
             <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+            <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+            <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
         </config-file>
 
         <source-file

--- a/plugin.xml
+++ b/plugin.xml
@@ -141,7 +141,6 @@
             <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
             <uses-permission android:name="android.permission.WAKE_LOCK" />
             <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
-            <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
             <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
         </config-file>
 

--- a/src/android/ClickReceiver.java
+++ b/src/android/ClickReceiver.java
@@ -22,7 +22,7 @@
 package de.appplant.cordova.plugin.localnotification;
 
 import android.os.Bundle;
-import android.support.v4.app.RemoteInput;
+import androidx.core.app.RemoteInput;
 
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/src/android/LocalNotification.java
+++ b/src/android/LocalNotification.java
@@ -211,8 +211,17 @@ public class LocalNotification extends CordovaPlugin {
      *                JavaScript.
      */
     private void check (CallbackContext command) {
-        boolean allowed = getNotMgr().hasPermission();
-        success(command, allowed);
+        /*
+         * Always true so the code can proceed and schedule the notification.
+         * If false is returned, then no schedule is created.
+         *
+         * Why was this necessary?
+         * By getting this value from 'getNotMgr().hasPermission()', a permission request
+         * popup is presented. However, the user won't have enough time to grand the permission
+         * before the success is sent with 'false' value.
+         * This prevented the notification from being schedule the first time the app opens.
+         */
+        success(command, true);
     }
 
     /**

--- a/src/android/LocalNotification.java
+++ b/src/android/LocalNotification.java
@@ -27,6 +27,7 @@ import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.KeyguardManager;
 import android.content.Context;
+import android.os.Build;
 import android.util.Log;
 import android.util.Pair;
 import android.view.View;
@@ -35,6 +36,7 @@ import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaInterface;
 import org.apache.cordova.CordovaPlugin;
 import org.apache.cordova.CordovaWebView;
+import org.apache.cordova.PermissionHelper;
 import org.apache.cordova.PluginResult;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -62,6 +64,9 @@ import static de.appplant.cordova.plugin.notification.Notification.Type.TRIGGERE
 @SuppressWarnings({"Convert2Diamond", "Convert2Lambda"})
 public class LocalNotification extends CordovaPlugin {
 
+    private static final int NOTIFICATION_PERMISSION_CODE = 43334;
+    private static final String NOTIFICATION_PERMISSION = "android.permission.POST_NOTIFICATIONS";
+
     // Reference to the web view for static access
     private static WeakReference<CordovaWebView> webView = null;
 
@@ -73,6 +78,10 @@ public class LocalNotification extends CordovaPlugin {
 
     // Launch details
     private static Pair<Integer, String> launchDetails;
+
+    //Save callback context
+    private CallbackContext callbackContext = null;
+    private JSONArray notificationArguments = null;
 
     /**
      * Called after plugin construction and fields have been initialized.
@@ -204,6 +213,14 @@ public class LocalNotification extends CordovaPlugin {
         launchDetails = null;
     }
 
+    @Override
+    public void onRequestPermissionResult(int requestCode, String[] permissions, int[] grantResults) throws JSONException {
+        super.onRequestPermissionResult(requestCode, permissions, grantResults);
+        if(requestCode == NOTIFICATION_PERMISSION_CODE){
+            scheduleWithPermission();
+        }
+    }
+
     /**
      * Ask if user has enabled permission for local notifications.
      *
@@ -272,10 +289,22 @@ public class LocalNotification extends CordovaPlugin {
      *                JavaScript.
      */
     private void schedule (JSONArray toasts, CallbackContext command) {
+        callbackContext = command;
+        notificationArguments = toasts;
+
+        if(Build.VERSION.SDK_INT >= 33 && !PermissionHelper.hasPermission(this, NOTIFICATION_PERMISSION)){
+            PermissionHelper.requestPermission(this, NOTIFICATION_PERMISSION_CODE, NOTIFICATION_PERMISSION);
+        }
+        else{
+            scheduleWithPermission();
+        }
+    }
+
+    private void scheduleWithPermission(){
         Manager mgr = getNotMgr();
 
-        for (int i = 0; i < toasts.length(); i++) {
-            JSONObject dict    = toasts.optJSONObject(i);
+        for (int i = 0; i < notificationArguments.length(); i++) {
+            JSONObject dict    = notificationArguments.optJSONObject(i);
             Options options    = new Options(cordova.getActivity(), dict);
             Request request    = new Request(options);
             Notification toast = mgr.schedule(request, TriggerReceiver.class);
@@ -284,8 +313,7 @@ public class LocalNotification extends CordovaPlugin {
                 fireEvent("add", toast);
             }
         }
-
-        check(command);
+        success(callbackContext, true);
     }
 
     /**

--- a/src/android/notification/Manager.java
+++ b/src/android/notification/Manager.java
@@ -29,7 +29,7 @@ import android.app.NotificationManager;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.service.notification.StatusBarNotification;
-import android.support.v4.app.NotificationManagerCompat;
+import androidx.core.app.NotificationManagerCompat;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -43,7 +43,7 @@ import de.appplant.cordova.plugin.badge.BadgeImpl;
 import static android.os.Build.VERSION.SDK_INT;
 import static android.os.Build.VERSION_CODES.M;
 import static android.os.Build.VERSION_CODES.O;
-import static android.support.v4.app.NotificationManagerCompat.IMPORTANCE_DEFAULT;
+import static androidx.core.app.NotificationManagerCompat.IMPORTANCE_DEFAULT;
 import static de.appplant.cordova.plugin.notification.Notification.PREF_KEY_ID;
 import static de.appplant.cordova.plugin.notification.Notification.Type.SCHEDULED;
 import static de.appplant.cordova.plugin.notification.Notification.Type.TRIGGERED;

--- a/src/android/notification/Options.java
+++ b/src/android/notification/Options.java
@@ -29,8 +29,8 @@ import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
-import android.support.v4.app.NotificationCompat;
-import android.support.v4.app.NotificationCompat.MessagingStyle.Message;
+import androidx.core.app.NotificationCompat;
+import androidx.core.app.NotificationCompat.MessagingStyle.Message;
 import android.support.v4.media.session.MediaSessionCompat;
 
 import org.json.JSONArray;
@@ -45,13 +45,13 @@ import de.appplant.cordova.plugin.notification.action.Action;
 import de.appplant.cordova.plugin.notification.action.ActionGroup;
 import de.appplant.cordova.plugin.notification.util.AssetUtil;
 
-import static android.support.v4.app.NotificationCompat.DEFAULT_LIGHTS;
-import static android.support.v4.app.NotificationCompat.DEFAULT_SOUND;
-import static android.support.v4.app.NotificationCompat.DEFAULT_VIBRATE;
-import static android.support.v4.app.NotificationCompat.PRIORITY_MAX;
-import static android.support.v4.app.NotificationCompat.PRIORITY_MIN;
-import static android.support.v4.app.NotificationCompat.VISIBILITY_PUBLIC;
-import static android.support.v4.app.NotificationCompat.VISIBILITY_SECRET;
+import static androidx.core.app.NotificationCompat.DEFAULT_LIGHTS;
+import static androidx.core.app.NotificationCompat.DEFAULT_SOUND;
+import static androidx.core.app.NotificationCompat.DEFAULT_VIBRATE;
+import static androidx.core.app.NotificationCompat.PRIORITY_MAX;
+import static androidx.core.app.NotificationCompat.PRIORITY_MIN;
+import static androidx.core.app.NotificationCompat.VISIBILITY_PUBLIC;
+import static androidx.core.app.NotificationCompat.VISIBILITY_SECRET;
 
 /**
  * Wrapper around the JSON object passed through JS which contains all

--- a/src/android/notification/action/Action.java
+++ b/src/android/notification/action/Action.java
@@ -22,7 +22,7 @@
 package de.appplant.cordova.plugin.notification.action;
 
 import android.content.Context;
-import android.support.v4.app.RemoteInput;
+import androidx.core.app.RemoteInput;
 
 import org.json.JSONArray;
 import org.json.JSONObject;

--- a/src/android/notification/util/AssetProvider.java
+++ b/src/android/notification/util/AssetProvider.java
@@ -19,7 +19,7 @@
 
 package de.appplant.cordova.plugin.notification.util;
 
-import android.support.v4.content.FileProvider;
+import androidx.core.content.FileProvider;
 
 public class AssetProvider extends FileProvider {
     // Nothing to do here


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This PR implements a fix to allow the POST_NOTIFICATION permission request.
Starting on API 33, we need to request this permission to be able to receive notifications on the device.

For now, we are not checking the response of the user to the notification permission dialog. We will schedule a notification either way. In the future, when this is aligned with the iOS side, we should check this response and act accordingly.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
References: https://outsystemsrd.atlassian.net/browse/RMET-1669
References: https://outsystemsrd.atlassian.net/browse/RMET-1833

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
Tested in Android API 33 emulator and older APIs devices.

## Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/27646996/191319038-ee3389ba-543e-44c8-9832-687041b6a354.png)
![image](https://user-images.githubusercontent.com/27646996/191319180-7bfbe512-0e5a-40fb-a3a4-e794753fd1bc.png)


## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
