### PR TITLE
RMET-2036 - Removed dependency to jcenter()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Please also read the [Upgrade Guide](https://github.com/katzer/cordova-plugin-lo
 
 #### Unreleased
 
+### 16-12-2022
+- Removed dependency to jcenter [RMET-2036](https://outsystemsrd.atlassian.net/browse/RMET-2036)
+
 #### Version 0.9.9 (21.09.2022)
 - Fix required for Android 13 regarding notification permissions (https://outsystemsrd.atlassian.net/browse/RMET-1833)
 

--- a/src/android/build/localnotification.gradle
+++ b/src/android/build/localnotification.gradle
@@ -17,7 +17,6 @@
 
 repositories {
     mavenCentral()
-    jcenter()
     maven {
         url "https://maven.google.com"
     }


### PR DESCRIPTION
## Description
- Removed the dependency to `jcenter()` from gradle

## Context
https://outsystemsrd.atlassian.net/browse/RMET-2036

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [X] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [X] Android
- [ ] iOS
- [ ] JavaScript

## Tests
Tested on MABS 8 and MABS 9 builds, on Android 12 device.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [X] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [X] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
