### PR TITLE
RMET-2665 :: Exact and Inexact notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Please also read the [Upgrade Guide](https://github.com/katzer/cordova-plugin-lo
 
 #### Unreleased
 
+### 04-08-2023
+- Added exact and inexact notifications [RMET-2665](https://outsystemsrd.atlassian.net/browse/RMET-2665)
+- Fixed Android 14 bug [RMET-2582](https://outsystemsrd.atlassian.net/browse/RMET-2582)
+
 #### Version 0.9.10 (19.12.2022)
 ### 16-12-2022
 - Removed dependency to jcenter [RMET-2036](https://outsystemsrd.atlassian.net/browse/RMET-2036)

--- a/plugin.xml
+++ b/plugin.xml
@@ -149,6 +149,10 @@
             target-dir="res/xml" />
 
         <source-file
+            src="src/android/OSLCNOError.java"
+            target-dir="src/de/appplant/cordova/plugin/localnotification" />
+
+        <source-file
             src="src/android/LocalNotification.java"
             target-dir="src/de/appplant/cordova/plugin/localnotification" />
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -153,6 +153,14 @@
             target-dir="src/de/appplant/cordova/plugin/localnotification" />
 
         <source-file
+            src="src/android/OSLCNOWarning.java"
+            target-dir="src/de/appplant/cordova/plugin/localnotification" />
+
+        <source-file
+            src="src/android/OSLCNOPluginMessage.java"
+            target-dir="src/de/appplant/cordova/plugin/localnotification" />
+
+        <source-file
             src="src/android/LocalNotification.java"
             target-dir="src/de/appplant/cordova/plugin/localnotification" />
 

--- a/src/android/LocalNotification.java
+++ b/src/android/LocalNotification.java
@@ -121,7 +121,7 @@ public class LocalNotification extends CordovaPlugin {
 
         requestingNotificationsPermissions = false;
     }
-    
+
     /**
      * The final call you receive before your activity is destroyed.
      */

--- a/src/android/LocalNotification.java
+++ b/src/android/LocalNotification.java
@@ -310,7 +310,9 @@ public class LocalNotification extends CordovaPlugin {
         callbackContext = command;
         notificationArguments = toasts;
 
-        if(Build.VERSION.SDK_INT >= 33 && !PermissionHelper.hasPermission(this, NOTIFICATION_PERMISSION)){
+        if(Build.VERSION.SDK_INT >= 33
+        && !PermissionHelper.hasPermission(this, NOTIFICATION_PERMISSION)
+        && !requestingNotificationsPermissions){
             requestingNotificationsPermissions = true;
             PermissionHelper.requestPermission(this, NOTIFICATION_PERMISSION_CODE, NOTIFICATION_PERMISSION);
         }

--- a/src/android/LocalNotification.java
+++ b/src/android/LocalNotification.java
@@ -48,6 +48,7 @@ import org.json.JSONObject;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Predicate;
 
 import de.appplant.cordova.plugin.notification.Manager;
 import de.appplant.cordova.plugin.notification.Notification;
@@ -92,7 +93,7 @@ public class LocalNotification extends CordovaPlugin {
      */
     private boolean requestingNotificationsPermissions = false;
     private boolean requestingExactAlarmPermission = false;
-    private OSLCNOError warning = null;
+    private OSLCNOWarning warning = null;
 
     /**
      * Called after plugin construction and fields have been initialized.
@@ -349,14 +350,7 @@ public class LocalNotification extends CordovaPlugin {
      * @return true if there's at least one exact notification. false otherwise.
      */
     private boolean hasAnyExactNotification() {
-        for (int i = 0; i < notificationArguments.length(); i++) {
-            JSONObject dict    = notificationArguments.optJSONObject(i);
-            Options options    = new Options(cordova.getActivity(), dict);
-            if(options.getIsExactNotification()) {
-                return true;
-            }
-        }
-        return false;
+        return findOptionsWithPredicate(Options::getIsExactNotification);
     }
 
     /**
@@ -365,10 +359,20 @@ public class LocalNotification extends CordovaPlugin {
      * @return true if there's at least one mandatory notification. false otherwise.
      */
     private boolean hasAnyMandatoryExactNotification() {
+        return findOptionsWithPredicate(Options::getIsExactMandatory);
+    }
+
+    /**
+     * Applies a predicate for all options from notification arguments
+     *
+     * @param predicate the predicate to apply
+     * @return
+     */
+    private boolean findOptionsWithPredicate(Predicate<Options> predicate) {
         for (int i = 0; i < notificationArguments.length(); i++) {
-            JSONObject dict    = notificationArguments.optJSONObject(i);
-            Options options    = new Options(cordova.getActivity(), dict);
-            if(options.getIsExactMandatory()) {
+            JSONObject dict = notificationArguments.optJSONObject(i);
+            Options options = new Options(cordova.getActivity(), dict);
+            if(predicate.test(options)) {
                 return true;
             }
         }
@@ -408,17 +412,15 @@ public class LocalNotification extends CordovaPlugin {
                 /*  permission was denied but there's at least one mandatory exact notification
                  *  send an error and finish execution
                  */
-                sendScheduleResult(callbackContext, PluginResult.Status.ERROR, OSLCNOError.EXACT_PERMISSION_ERROR);
+                sendScheduleResult(callbackContext, PluginResult.Status.ERROR, OSLCNOError.EXACT_PERMISSION);
                 return;
             }
-            else {
-                /*  permission was denied and there's no mandatory exact notification
-                 *  change all notifications to inexact and continue flow normally
-                 *  send a warning when execution is done
-                 */
-                setAllNotificationsAsInexact();
-                warning = OSLCNOError.EXACT_PERMISSION_WARNING;
-            }
+            /*  permission was denied and there's no mandatory exact notification
+             *  change all notifications to inexact and continue flow normally
+             *  send a warning when execution is done
+             */
+            setAllNotificationsAsInexact();
+            warning = OSLCNOWarning.EXACT_PERMISSION;
         }
 
         schedule(notificationArguments, callbackContext);
@@ -675,15 +677,10 @@ public class LocalNotification extends CordovaPlugin {
      */
     private void sendScheduleResult(CallbackContext command,
                                     PluginResult.Status status,
-                                    OSLCNOError error) {
-
-        if(error == null) {
-            command.sendPluginResult(new PluginResult(status));
-            return;
-        }
-
-        JSONObject errorJSON = error.toJSONObject();;
-        command.sendPluginResult(new PluginResult(status, errorJSON));
+                                    OSLCNOPluginMessage message) {
+        command.sendPluginResult(message != null ?
+                new PluginResult(status, message.toJSONObject()) :
+                new PluginResult(status));
     }
 
     /**

--- a/src/android/LocalNotification.java
+++ b/src/android/LocalNotification.java
@@ -121,13 +121,7 @@ public class LocalNotification extends CordovaPlugin {
 
         requestingNotificationsPermissions = false;
     }
-
-    @Override
-    public void onPause(boolean multitasking) {
-        super.onPause(multitasking);
-
-    }
-
+    
     /**
      * The final call you receive before your activity is destroyed.
      */

--- a/src/android/LocalNotification.java
+++ b/src/android/LocalNotification.java
@@ -88,6 +88,7 @@ public class LocalNotification extends CordovaPlugin {
 
     // Used when trying to schedule a notification with exact alarm
     private boolean requestingExactAlarmPermission = false;
+    private OSLCNOError warning = null;
 
     /**
      * Called after plugin construction and fields have been initialized.
@@ -328,11 +329,14 @@ public class LocalNotification extends CordovaPlugin {
                 fireEvent("add", toast);
             }
         }
-        success(callbackContext, true);
+
+        sendScheduleResult(callbackContext, PluginResult.Status.OK, warning);
+        warning = null;
+
     }
 
     /**
-     * Check is there's any notification to be scheduled as exact.
+     * Checks if there's any notification to be scheduled as exact.
      *
      * @return true if there's at least one exact notification. false otherwise.
      */
@@ -340,7 +344,7 @@ public class LocalNotification extends CordovaPlugin {
         for (int i = 0; i < notificationArguments.length(); i++) {
             JSONObject dict    = notificationArguments.optJSONObject(i);
             Options options    = new Options(cordova.getActivity(), dict);
-            if(options.getIsExactSchedule()) {
+            if(options.getIsExactNotification()) {
                 return true;
             }
         }
@@ -348,7 +352,7 @@ public class LocalNotification extends CordovaPlugin {
     }
 
     /**
-     * Check is there's any notification that is mandatory to be scheduled as exact.
+     * Checks if there's any notification that is mandatory to be scheduled as exact.
      *
      * @return true if there's at least one mandatory notification. false otherwise.
      */
@@ -370,7 +374,7 @@ public class LocalNotification extends CordovaPlugin {
         for (int i = 0; i < notificationArguments.length(); i++) {
             JSONObject dict    = notificationArguments.optJSONObject(i);
             Options options    = new Options(cordova.getActivity(), dict);
-            options.setIsExactSchedule(false);
+            options.setIsExactNotification(false);
         }
     }
 
@@ -396,7 +400,7 @@ public class LocalNotification extends CordovaPlugin {
                 /*  permission was denied but there's at least one mandatory exact notification
                  *  send an error and finish execution
                  */
-                error(callbackContext, "Error: 123123");
+                sendScheduleResult(callbackContext, PluginResult.Status.ERROR, OSLCNOError.EXACT_PERMISSION_ERROR);
                 return;
             }
             else {
@@ -404,6 +408,7 @@ public class LocalNotification extends CordovaPlugin {
                  *  change all notifications to inexact and continue flow normally
                  */
                 setAllNotificationsAsInexact();
+                warning = OSLCNOError.EXACT_PERMISSION_WARNING;
             }
         }
 
@@ -659,9 +664,17 @@ public class LocalNotification extends CordovaPlugin {
      * Invoke error callback with a string boolean argument.
      *
      */
-    private void error(CallbackContext command, String arg) {
-        PluginResult result = new PluginResult(PluginResult.Status.ERROR, arg);
-        command.sendPluginResult(result);
+    private void sendScheduleResult(CallbackContext command,
+                                    PluginResult.Status status,
+                                    OSLCNOError error) {
+
+        if(error == null) {
+            command.sendPluginResult(new PluginResult(status));
+            return;
+        }
+
+        JSONObject errorJSON = error.toJSONObject();;
+        command.sendPluginResult(new PluginResult(status, errorJSON));
     }
 
     /**

--- a/src/android/LocalNotification.java
+++ b/src/android/LocalNotification.java
@@ -23,10 +23,13 @@
 
 package de.appplant.cordova.plugin.localnotification;
 
+import static android.provider.Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM;
+
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.KeyguardManager;
 import android.content.Context;
+import android.content.Intent;
 import android.os.Build;
 import android.util.Log;
 import android.util.Pair;
@@ -83,6 +86,9 @@ public class LocalNotification extends CordovaPlugin {
     private CallbackContext callbackContext = null;
     private JSONArray notificationArguments = null;
 
+    // Used when trying to schedule a notification with exact alarm
+    private boolean requestingExactAlarmPermission = false;
+
     /**
      * Called after plugin construction and fields have been initialized.
      * Prefer to use pluginInitialize instead since there is no value in
@@ -102,6 +108,12 @@ public class LocalNotification extends CordovaPlugin {
     public void onResume (boolean multitasking) {
         super.onResume(multitasking);
         deviceready();
+
+        // check if this was a permission request for scheduling exact alarms
+        if(requestingExactAlarmPermission) {
+            requestingExactAlarmPermission = false;
+            onScheduleExactAlarmPermissionResult();
+        }
     }
 
     /**
@@ -295,7 +307,10 @@ public class LocalNotification extends CordovaPlugin {
         if(Build.VERSION.SDK_INT >= 33 && !PermissionHelper.hasPermission(this, NOTIFICATION_PERMISSION)){
             PermissionHelper.requestPermission(this, NOTIFICATION_PERMISSION_CODE, NOTIFICATION_PERMISSION);
         }
-        else{
+        else if(hasAnyExactNotification() && !getNotMgr().canScheduleExactAlarms()) {
+            requestScheduleExactAlarmPermission();
+        }
+        else {
             scheduleWithPermission();
         }
     }
@@ -314,6 +329,85 @@ public class LocalNotification extends CordovaPlugin {
             }
         }
         success(callbackContext, true);
+    }
+
+    /**
+     * Check is there's any notification to be scheduled as exact.
+     *
+     * @return true if there's at least one exact notification. false otherwise.
+     */
+    private boolean hasAnyExactNotification() {
+        for (int i = 0; i < notificationArguments.length(); i++) {
+            JSONObject dict    = notificationArguments.optJSONObject(i);
+            Options options    = new Options(cordova.getActivity(), dict);
+            if(options.getIsExactSchedule()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Check is there's any notification that is mandatory to be scheduled as exact.
+     *
+     * @return true if there's at least one mandatory notification. false otherwise.
+     */
+    private boolean hasAnyMandatoryExactNotification() {
+        for (int i = 0; i < notificationArguments.length(); i++) {
+            JSONObject dict    = notificationArguments.optJSONObject(i);
+            Options options    = new Options(cordova.getActivity(), dict);
+            if(options.getIsExactMandatory()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Sets all notification's options to be scheduled as Inexact alarms.
+     */
+    private void setAllNotificationsAsInexact() {
+        for (int i = 0; i < notificationArguments.length(); i++) {
+            JSONObject dict    = notificationArguments.optJSONObject(i);
+            Options options    = new Options(cordova.getActivity(), dict);
+            options.setIsExactSchedule(false);
+        }
+    }
+
+    /**
+     * Requests user permission to schedule exact alarms.
+     * The result should be present on onResume method.
+     *
+     */
+    private void requestScheduleExactAlarmPermission() {
+        requestingExactAlarmPermission = true;
+        cordova.getContext().startActivity(new Intent(ACTION_REQUEST_SCHEDULE_EXACT_ALARM));
+    }
+
+    /**
+     * Handles user response to exact alarm permission request.
+     *
+     */
+    private void onScheduleExactAlarmPermissionResult() {
+        Boolean permissionDenied = !getNotMgr().canScheduleExactAlarms();
+
+        if(permissionDenied) {
+            if(hasAnyMandatoryExactNotification()) {
+                /*  permission was denied but there's at least one mandatory exact notification
+                 *  send an error and finish execution
+                 */
+                error(callbackContext, "Error: 123123");
+                return;
+            }
+            else {
+                /*  permission was denied and there's no mandatory exact notification
+                 *  change all notifications to inexact and continue flow normally
+                 */
+                setAllNotificationsAsInexact();
+            }
+        }
+
+        scheduleWithPermission();
     }
 
     /**
@@ -558,6 +652,15 @@ public class LocalNotification extends CordovaPlugin {
      */
     private void success(CallbackContext command, boolean arg) {
         PluginResult result = new PluginResult(PluginResult.Status.OK, arg);
+        command.sendPluginResult(result);
+    }
+
+    /**
+     * Invoke error callback with a string boolean argument.
+     *
+     */
+    private void error(CallbackContext command, String arg) {
+        PluginResult result = new PluginResult(PluginResult.Status.ERROR, arg);
         command.sendPluginResult(result);
     }
 

--- a/src/android/LocalNotification.java
+++ b/src/android/LocalNotification.java
@@ -229,7 +229,7 @@ public class LocalNotification extends CordovaPlugin {
     public void onRequestPermissionResult(int requestCode, String[] permissions, int[] grantResults) throws JSONException {
         super.onRequestPermissionResult(requestCode, permissions, grantResults);
         if(requestCode == NOTIFICATION_PERMISSION_CODE){
-            scheduleWithPermission();
+            schedule(notificationArguments, callbackContext);
         }
     }
 
@@ -380,8 +380,8 @@ public class LocalNotification extends CordovaPlugin {
      *
      */
     private void requestScheduleExactAlarmPermission() {
-        requestingExactAlarmPermission = true;
         cordova.getContext().startActivity(new Intent(ACTION_REQUEST_SCHEDULE_EXACT_ALARM));
+        requestingExactAlarmPermission = true;
     }
 
     /**
@@ -407,7 +407,7 @@ public class LocalNotification extends CordovaPlugin {
             }
         }
 
-        scheduleWithPermission();
+        schedule(notificationArguments, callbackContext);
     }
 
     /**

--- a/src/android/LocalNotification.java
+++ b/src/android/LocalNotification.java
@@ -86,7 +86,11 @@ public class LocalNotification extends CordovaPlugin {
     private CallbackContext callbackContext = null;
     private JSONArray notificationArguments = null;
 
-    // Used when trying to schedule a notification with exact alarm
+    /**
+     * We need this variable because the onResume is being called when user
+     * grants permissions to receive notifications. What a mess.
+     */
+    private boolean requestingNotificationsPermissions = false;
     private boolean requestingExactAlarmPermission = false;
     private OSLCNOError warning = null;
 
@@ -110,11 +114,18 @@ public class LocalNotification extends CordovaPlugin {
         super.onResume(multitasking);
         deviceready();
 
-        // check if this was a permission request for scheduling exact alarms
-        if(requestingExactAlarmPermission) {
+        if(!requestingNotificationsPermissions && requestingExactAlarmPermission) {
             requestingExactAlarmPermission = false;
             onScheduleExactAlarmPermissionResult();
         }
+
+        requestingNotificationsPermissions = false;
+    }
+
+    @Override
+    public void onPause(boolean multitasking) {
+        super.onPause(multitasking);
+
     }
 
     /**
@@ -306,6 +317,7 @@ public class LocalNotification extends CordovaPlugin {
         notificationArguments = toasts;
 
         if(Build.VERSION.SDK_INT >= 33 && !PermissionHelper.hasPermission(this, NOTIFICATION_PERMISSION)){
+            requestingNotificationsPermissions = true;
             PermissionHelper.requestPermission(this, NOTIFICATION_PERMISSION_CODE, NOTIFICATION_PERMISSION);
         }
         else if(hasAnyExactNotification() && !getNotMgr().canScheduleExactAlarms()) {
@@ -384,8 +396,8 @@ public class LocalNotification extends CordovaPlugin {
      *
      */
     private void requestScheduleExactAlarmPermission() {
-        cordova.getContext().startActivity(new Intent(ACTION_REQUEST_SCHEDULE_EXACT_ALARM));
         requestingExactAlarmPermission = true;
+        cordova.getContext().startActivity(new Intent(ACTION_REQUEST_SCHEDULE_EXACT_ALARM));
     }
 
     /**
@@ -406,6 +418,7 @@ public class LocalNotification extends CordovaPlugin {
             else {
                 /*  permission was denied and there's no mandatory exact notification
                  *  change all notifications to inexact and continue flow normally
+                 *  send a warning when execution is done
                  */
                 setAllNotificationsAsInexact();
                 warning = OSLCNOError.EXACT_PERMISSION_WARNING;

--- a/src/android/OSLCNOError.java
+++ b/src/android/OSLCNOError.java
@@ -1,37 +1,12 @@
 package de.appplant.cordova.plugin.localnotification;
 
-import org.json.JSONException;
-import org.json.JSONObject;
-
-public class OSLCNOError {
-
-    private final String code;
-    private final String message;
-
-    public String getCode() { return code; }
-    public String getMessage() { return message; }
+public class OSLCNOError extends OSLCNOPluginMessage {
 
     public OSLCNOError(String code, String message) {
-        this.code = code;
-        this.message = message;
+        super(code, message);
     }
 
-    static OSLCNOError EXACT_PERMISSION_ERROR =
+    static final OSLCNOError EXACT_PERMISSION =
             new OSLCNOError("OSLCNO-001","Unable to schedule an exact alarm due to lack of permissions.");
-
-    static OSLCNOError EXACT_PERMISSION_WARNING =
-            new OSLCNOError("OSLCNO-002","Unable to schedule an exact alarm due to lack of permissions. We scheduled it as an inexact alarm instead.");
-
-    public JSONObject toJSONObject() {
-        JSONObject jsonResult = new JSONObject();
-        try {
-            jsonResult.put("code", code);
-            jsonResult.put("message", message);
-            return jsonResult;
-        } catch (JSONException e) {
-            // should never happen
-            return null;
-        }
-    }
 
 }

--- a/src/android/OSLCNOError.java
+++ b/src/android/OSLCNOError.java
@@ -1,0 +1,37 @@
+package de.appplant.cordova.plugin.localnotification;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+public class OSLCNOError {
+
+    private final String code;
+    private final String message;
+
+    public String getCode() { return code; }
+    public String getMessage() { return message; }
+
+    public OSLCNOError(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    static OSLCNOError EXACT_PERMISSION_ERROR =
+            new OSLCNOError("OSLCNO-001","Unable to schedule an exact alarm due to lack of permissions.");
+
+    static OSLCNOError EXACT_PERMISSION_WARNING =
+            new OSLCNOError("OSLCNO-002","Unable to schedule an exact alarm due to lack of permissions. We scheduled it as an inexact alarm instead.");
+
+    public JSONObject toJSONObject() {
+        JSONObject jsonResult = new JSONObject();
+        try {
+            jsonResult.put("code", code);
+            jsonResult.put("message", message);
+            return jsonResult;
+        } catch (JSONException e) {
+            // should never happen
+            return null;
+        }
+    }
+
+}

--- a/src/android/OSLCNOPluginMessage.java
+++ b/src/android/OSLCNOPluginMessage.java
@@ -1,0 +1,31 @@
+package de.appplant.cordova.plugin.localnotification;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+abstract class OSLCNOPluginMessage {
+
+    private final String code;
+    private final String message;
+
+    public String getCode() { return code; }
+    public String getMessage() { return message; }
+
+    public OSLCNOPluginMessage(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    public JSONObject toJSONObject() {
+        JSONObject jsonResult = new JSONObject();
+        try {
+            jsonResult.put("code", code);
+            jsonResult.put("message", message);
+            return jsonResult;
+        } catch (JSONException e) {
+            // should never happen
+            return null;
+        }
+    }
+
+}

--- a/src/android/OSLCNOWarning.java
+++ b/src/android/OSLCNOWarning.java
@@ -1,0 +1,12 @@
+package de.appplant.cordova.plugin.localnotification;
+
+public class OSLCNOWarning extends OSLCNOPluginMessage {
+
+    public OSLCNOWarning(String code, String message) {
+        super(code, message);
+    }
+
+    static OSLCNOWarning EXACT_PERMISSION =
+            new OSLCNOWarning("OSLCNO-002","Unable to schedule an exact alarm due to lack of permissions. We scheduled it as an inexact alarm instead.");
+
+}

--- a/src/android/notification/Manager.java
+++ b/src/android/notification/Manager.java
@@ -24,10 +24,12 @@
 package de.appplant.cordova.plugin.notification;
 
 import android.annotation.SuppressLint;
+import android.app.AlarmManager;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.os.Build;
 import android.service.notification.StatusBarNotification;
 import androidx.core.app.NotificationManagerCompat;
 
@@ -88,6 +90,15 @@ public final class Manager {
      */
     public boolean hasPermission () {
         return getNotCompMgr().areNotificationsEnabled();
+    }
+
+    /**
+     * Checks whether or not the app has permission to schedule exact alarms.
+     * @return true if there's permission to schedule exact alarms. false otherwise.
+     */
+    public boolean canScheduleExactAlarms() {
+        // Should always be true when working with Android 12 (API level 32) or below.
+        return Build.VERSION.SDK_INT <= 32 || getAlarmMgr().canScheduleExactAlarms();
     }
 
     /**
@@ -430,6 +441,12 @@ public final class Manager {
         return NotificationManagerCompat.from(context);
     }
 
+    /**
+     * Alarm manager for the application.
+     */
+    private AlarmManager getAlarmMgr () {
+        return (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+    }
 }
 
 // codebeat:enable[TOO_MANY_FUNCTIONS]

--- a/src/android/notification/Notification.java
+++ b/src/android/notification/Notification.java
@@ -33,7 +33,6 @@ import androidx.core.app.NotificationCompat;
 import androidx.collection.ArraySet;
 import androidx.core.util.Pair;
 
-import android.os.Build;
 import android.util.Log;
 import android.util.SparseArray;
 
@@ -282,7 +281,7 @@ public final class Notification {
 
         AlarmManager mgr = getAlarmMgr();
         if(allowWhileIdle) {
-            if(options.getIsExactSchedule()) {
+            if(options.getIsExactNotification()) {
                 mgr.setExactAndAllowWhileIdle(type, triggerMillis, operation);
             }
             else {
@@ -290,7 +289,7 @@ public final class Notification {
             }
         }
         else {
-            if(options.getIsExactSchedule()) {
+            if(options.getIsExactNotification()) {
                 mgr.setExact(type, triggerMillis, operation);
             }
             else {

--- a/src/android/notification/Notification.java
+++ b/src/android/notification/Notification.java
@@ -255,21 +255,46 @@ public final class Notification {
                 switch (options.getPrio()) {
                     case PRIORITY_MIN:
                         mgr.setExact(RTC, time, pi);
+                        scheduleNotification(false, RTC, time, pi);
                         break;
                     case PRIORITY_MAX:
                         if (SDK_INT >= M) {
-                            mgr.setExactAndAllowWhileIdle(RTC_WAKEUP, time, pi);
+                            scheduleNotification(true, RTC_WAKEUP, time, pi);
                         } else {
-                            mgr.setExact(RTC, time, pi);
+                            scheduleNotification(false, RTC, time, pi);
                         }
                         break;
                     default:
-                        mgr.setExact(RTC_WAKEUP, time, pi);
+                        scheduleNotification(false, RTC_WAKEUP, time, pi);
                         break;
                 }
             } catch (Exception ignore) {
                 // Samsung devices have a known bug where a 500 alarms limit
                 // can crash the app
+            }
+        }
+    }
+
+    private void scheduleNotification(boolean allowWhileIdle,
+                                      int type,
+                                      long triggerMillis,
+                                      PendingIntent operation) {
+
+        AlarmManager mgr = getAlarmMgr();
+        if(allowWhileIdle) {
+            if(options.getIsExactSchedule()) {
+                mgr.setExactAndAllowWhileIdle(type, triggerMillis, operation);
+            }
+            else {
+                mgr.setAndAllowWhileIdle(type, triggerMillis, operation);
+            }
+        }
+        else {
+            if(options.getIsExactSchedule()) {
+                mgr.setExact(type, triggerMillis, operation);
+            }
+            else {
+                mgr.set(type, triggerMillis, operation);
             }
         }
     }

--- a/src/android/notification/Notification.java
+++ b/src/android/notification/Notification.java
@@ -33,6 +33,7 @@ import androidx.core.app.NotificationCompat;
 import androidx.collection.ArraySet;
 import androidx.core.util.Pair;
 
+import android.os.Build;
 import android.util.Log;
 import android.util.SparseArray;
 
@@ -529,5 +530,4 @@ public final class Notification {
     private AlarmManager getAlarmMgr () {
         return (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
     }
-
 }

--- a/src/android/notification/Notification.java
+++ b/src/android/notification/Notification.java
@@ -267,7 +267,14 @@ public final class Notification {
                         scheduleNotification(false, RTC_WAKEUP, time, pi);
                         break;
                 }
-            } catch (Exception ignore) {
+            }
+            catch(SecurityException se) {
+                // thrown when trying to schedule an exact notification without permissions
+                // should never happen. Let's log just in case.
+                Log.e("notification", "Caught security exception when scheduling alarm.");
+                se.printStackTrace();
+            }
+            catch (Exception ignore) {
                 // Samsung devices have a known bug where a 500 alarms limit
                 // can crash the app
             }

--- a/src/android/notification/Notification.java
+++ b/src/android/notification/Notification.java
@@ -272,7 +272,6 @@ public final class Notification {
                 // thrown when trying to schedule an exact notification without permissions
                 // should never happen. Let's log just in case.
                 Log.e("notification", "Caught security exception when scheduling alarm.");
-                se.printStackTrace();
             }
             catch (Exception ignore) {
                 // Samsung devices have a known bug where a 500 alarms limit
@@ -295,13 +294,11 @@ public final class Notification {
                 mgr.setAndAllowWhileIdle(type, triggerMillis, operation);
             }
         }
+        else if(options.getIsExactNotification()) {
+            mgr.setExact(type, triggerMillis, operation);
+        }
         else {
-            if(options.getIsExactNotification()) {
-                mgr.setExact(type, triggerMillis, operation);
-            }
-            else {
-                mgr.set(type, triggerMillis, operation);
-            }
+            mgr.set(type, triggerMillis, operation);
         }
     }
 

--- a/src/android/notification/Options.java
+++ b/src/android/notification/Options.java
@@ -695,19 +695,19 @@ public final class Options {
     /**
      * Gets the property that dictates if the notification should be scheduled with an exact alarm.
      */
-    public boolean getIsExactSchedule() {
-        return options.optBoolean("isExactSchedule", false);
+    public boolean getIsExactNotification() {
+        return options.optBoolean("isExactNotification", false);
     }
 
     /**
      * Sets the property that dictates if the notification should be scheduled with an exact alarm.
      */
-    public void setIsExactSchedule(Boolean newValue) {
+    public void setIsExactNotification(Boolean newValue) {
         try {
-            options.put("isExactSchedule", newValue);
+            options.put("isExactNotification", newValue);
         } catch (Exception ignore) {
             ignore.getMessage();
-            // for now...
+            // this should never happen...
         }
     }
 

--- a/src/android/notification/Options.java
+++ b/src/android/notification/Options.java
@@ -32,6 +32,7 @@ import android.net.Uri;
 import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationCompat.MessagingStyle.Message;
 import android.support.v4.media.session.MediaSessionCompat;
+import android.util.Log;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -705,9 +706,10 @@ public final class Options {
     public void setIsExactNotification(Boolean newValue) {
         try {
             options.put("isExactNotification", newValue);
-        } catch (Exception ignore) {
-            ignore.getMessage();
-            // this should never happen...
+        } catch (Exception e) {
+            // this should never happen. Let's log just in case.
+            Log.e("options", "Caught security exception when setting IsExactNotification: " + e.getMessage());
+            e.printStackTrace();
         }
     }
 

--- a/src/android/notification/Options.java
+++ b/src/android/notification/Options.java
@@ -692,6 +692,31 @@ public final class Options {
         return (hex.charAt(0) == '#') ? hex.substring(1) : hex;
     }
 
+    /**
+     * Gets the property that dictates if the notification should be scheduled with an exact alarm.
+     */
+    public boolean getIsExactSchedule() {
+        return options.optBoolean("isExactSchedule", false);
+    }
+
+    /**
+     * Sets the property that dictates if the notification should be scheduled with an exact alarm.
+     */
+    public void setIsExactSchedule(Boolean newValue) {
+        try {
+            options.put("isExactSchedule", newValue);
+        } catch (Exception ignore) {
+            ignore.getMessage();
+            // for now...
+        }
+    }
+
+    /**
+     * Gets the property that dictates if its mandatory the notification should be scheduled with an exact alarm.
+     */
+    public boolean getIsExactMandatory() {
+        return options.optBoolean("isExactMandatory", false);
+    }
 }
 
 // codebeat:enable[TOO_MANY_FUNCTIONS]

--- a/src/android/notification/Options.java
+++ b/src/android/notification/Options.java
@@ -709,7 +709,6 @@ public final class Options {
         } catch (Exception e) {
             // this should never happen. Let's log just in case.
             Log.e("options", "Caught security exception when setting IsExactNotification: " + e.getMessage());
-            e.printStackTrace();
         }
     }
 


### PR DESCRIPTION
## Description
- Adds _isExactNotification_ and _isExactMandatory_ parameters;
- Adds the ability to return an error or warning when scheduling a notification;
- Fixes notification not showing on Android 14 by asking for exact alert permissions;

## Context
- https://outsystemsrd.atlassian.net/browse/RMET-2665
- https://outsystemsrd.atlassian.net/browse/RMET-2582

## Type of changes
- [x] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Testing
- MABS9 build (https://engineering.outsystems.net/MABS/BuildDetail.aspx?BuildId=f999ee494f7391ecfb9dc1697c68608707953104&StageId=1);
- Tested on Android 14 simulator;
- Tested on Android 12 device.

## Platforms affected
- [x] Android
- [ ] iOS
- [x] JavaScript

## Checklist
- [x] Pull request title follows the format `RMET-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [x] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly

