### PR TITLE
RMET-2823 Local Notifications Plugin - Replace Android Support with AndroidX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ ChangeLog
 Please also read the [Upgrade Guide](https://github.com/katzer/cordova-plugin-local-notifications/wiki/Upgrade-Guide) for more information.
 
 #### Unreleased
+### 11-09-2023
+- Android: Replace dependency on Android Support Libraries with AndroidX [RMET-2823](https://outsystemsrd.atlassian.net/browse/RMET-2823)
 
 #### Version 0.9.11 (28.08.2023)
 ### 04-08-2023

--- a/src/android/build/localnotification.gradle
+++ b/src/android/build/localnotification.gradle
@@ -26,21 +26,7 @@ if (!project.ext.has('appShortcutBadgerVersion')) {
     ext.appShortcutBadgerVersion = '1.1.19'
 }
 
-String getVersion() {
-  def compileSdkVersion = Integer.parseInt(project.android.compileSdkVersion.split("-")[1])
-  return compileSdkVersion >= 28 ? "28.0.0" : "26.+" 
-}
-
 dependencies {
     implementation "me.leolin:ShortcutBadger:${appShortcutBadgerVersion}@aar"
+    implementation 'androidx.media:media:1.6.0'
 }
-
-// Defer the definition of the dependencies to the end
-// of the "configuration" phase from the app build.gradle file
-// so that we can inquire the proper compile sdk version being used.
-cdvPluginPostBuildExtras.push({
-  dependencies {
-    implementation "com.android.support:support-v4:${getVersion()}"
-    implementation "com.android.support:support-core-utils:${getVersion()}"
-  }
-})


### PR DESCRIPTION
## Description
- Replaced the dependency to android's Support Library with its AndroidX counterpart.

## Context
https://outsystemsrd.atlassian.net/browse/RMET-2823

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [X] Android
- [ ] iOS
- [ ] JavaScript

## Tests

- Tested on MABS 10 and MABS 9.
- Note: MABS 10 builds running on Android 14 still need the fix that will be made in https://outsystemsrd.atlassian.net/browse/RMET-2666, but that fix is out of the scope of this PR.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [X] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [X] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
