### PR TITLE
RMET-2666 Local Notifications Plugin - Update pending intents for Android 14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ ChangeLog
 Please also read the [Upgrade Guide](https://github.com/katzer/cordova-plugin-local-notifications/wiki/Upgrade-Guide) for more information.
 
 #### Unreleased
+### 11-09-2023
+- Android: Replace dependency on Android Support Libraries with AndroidX [RMET-2823](https://outsystemsrd.atlassian.net/browse/RMET-2823)
 
 #### Version 0.9.11 (28.08.2023)
 ### 04-08-2023

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ ChangeLog
 Please also read the [Upgrade Guide](https://github.com/katzer/cordova-plugin-local-notifications/wiki/Upgrade-Guide) for more information.
 
 #### Unreleased
+
+### 12-09-2023
+- Android: Make PendingIntents immutable [RMET-2666](https://outsystemsrd.atlassian.net/browse/RMET-2666)
 ### 11-09-2023
 - Android: Replace dependency on Android Support Libraries with AndroidX [RMET-2823](https://outsystemsrd.atlassian.net/browse/RMET-2823)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Please also read the [Upgrade Guide](https://github.com/katzer/cordova-plugin-lo
 #### Unreleased
 
 ### 12-09-2023
-- Android: Make PendingIntents immutable [RMET-2666](https://outsystemsrd.atlassian.net/browse/RMET-2666)
+- Android: Make PendingIntents immutable for Android 14 [RMET-2666](https://outsystemsrd.atlassian.net/browse/RMET-2666)
 ### 11-09-2023
 - Android: Replace dependency on Android Support Libraries with AndroidX [RMET-2823](https://outsystemsrd.atlassian.net/browse/RMET-2823)
 

--- a/src/android/build/localnotification.gradle
+++ b/src/android/build/localnotification.gradle
@@ -26,21 +26,7 @@ if (!project.ext.has('appShortcutBadgerVersion')) {
     ext.appShortcutBadgerVersion = '1.1.19'
 }
 
-String getVersion() {
-  def compileSdkVersion = Integer.parseInt(project.android.compileSdkVersion.split("-")[1])
-  return compileSdkVersion >= 28 ? "28.0.0" : "26.+" 
-}
-
 dependencies {
     implementation "me.leolin:ShortcutBadger:${appShortcutBadgerVersion}@aar"
+    implementation 'androidx.media:media:1.6.0'
 }
-
-// Defer the definition of the dependencies to the end
-// of the "configuration" phase from the app build.gradle file
-// so that we can inquire the proper compile sdk version being used.
-cdvPluginPostBuildExtras.push({
-  dependencies {
-    implementation "com.android.support:support-v4:${getVersion()}"
-    implementation "com.android.support:support-core-utils:${getVersion()}"
-  }
-})

--- a/src/android/notification/Builder.java
+++ b/src/android/notification/Builder.java
@@ -327,11 +327,13 @@ public final class Builder {
 
         PendingIntent deleteIntent;
 
-        if(SDK_INT >= 31){
+        if (SDK_INT >= 34) {
+            deleteIntent = PendingIntent.getBroadcast(
+                    context, reqCode, intent, FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+        } else if (SDK_INT >= 31) {
             deleteIntent = PendingIntent.getBroadcast(
                     context, reqCode, intent, FLAG_UPDATE_CURRENT | 33554432);
-        }
-        else{
+        } else {
             deleteIntent = PendingIntent.getBroadcast(
                     context, reqCode, intent, FLAG_UPDATE_CURRENT);
         }
@@ -367,11 +369,13 @@ public final class Builder {
             myIntent.putExtras(extras);
         }
 
-        if(SDK_INT >= 31){
+        if (SDK_INT >= 34) {
+            contentIntent = PendingIntent.getActivity(
+                    context, reqCode, myIntent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+        } else if (SDK_INT >= 31) {
             contentIntent = PendingIntent.getActivity(
                     context, reqCode, myIntent, PendingIntent.FLAG_UPDATE_CURRENT | 33554432);
-        }
-        else{
+        } else {
             contentIntent = PendingIntent.getActivity(
                     context, reqCode, myIntent, PendingIntent.FLAG_UPDATE_CURRENT);
         }
@@ -425,11 +429,13 @@ public final class Builder {
 
         PendingIntent toReturn;
 
-        if(SDK_INT >= 31){
+        if (SDK_INT >= 34) {
+            toReturn = PendingIntent.getService(
+                    context, reqCode, intent, FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+        } else if (SDK_INT >= 31) {
             toReturn = PendingIntent.getService(
                     context, reqCode, intent, FLAG_UPDATE_CURRENT | 33554432);
-        }
-        else{
+        } else {
             toReturn = PendingIntent.getService(
                     context, reqCode, intent, FLAG_UPDATE_CURRENT);
         }

--- a/src/android/notification/Builder.java
+++ b/src/android/notification/Builder.java
@@ -325,19 +325,17 @@ public final class Builder {
 
         int reqCode = random.nextInt();
 
-        PendingIntent deleteIntent;
+        int flags;
 
         if (SDK_INT >= 34) {
-            deleteIntent = PendingIntent.getBroadcast(
-                    context, reqCode, intent, FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+            flags = FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE;
         } else if (SDK_INT >= 31) {
-            deleteIntent = PendingIntent.getBroadcast(
-                    context, reqCode, intent, FLAG_UPDATE_CURRENT | PendingIntent.FLAG_MUTABLE);
+            flags = FLAG_UPDATE_CURRENT | PendingIntent.FLAG_MUTABLE;
         } else {
-            deleteIntent = PendingIntent.getBroadcast(
-                    context, reqCode, intent, FLAG_UPDATE_CURRENT);
+            flags = FLAG_UPDATE_CURRENT;
         }
 
+        PendingIntent deleteIntent = PendingIntent.getBroadcast(context, reqCode, intent, flags);
         builder.setDeleteIntent(deleteIntent);
     }
 
@@ -354,8 +352,6 @@ public final class Builder {
 
         int reqCode = random.nextInt();
 
-        PendingIntent contentIntent;
-
         Bundle myBundle = new Bundle();
         myBundle.putInt(Notification.EXTRA_ID, options.getId());
         myBundle.putString(Action.EXTRA_ID, Action.CLICK_ACTION_ID);
@@ -369,17 +365,17 @@ public final class Builder {
             myIntent.putExtras(extras);
         }
 
+        int flags;
+
         if (SDK_INT >= 34) {
-            contentIntent = PendingIntent.getActivity(
-                    context, reqCode, myIntent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+            flags = PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE;
         } else if (SDK_INT >= 31) {
-            contentIntent = PendingIntent.getActivity(
-                    context, reqCode, myIntent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_MUTABLE);
+            flags = PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_MUTABLE;
         } else {
-            contentIntent = PendingIntent.getActivity(
-                    context, reqCode, myIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+            flags = PendingIntent.FLAG_UPDATE_CURRENT;
         }
 
+        PendingIntent contentIntent = PendingIntent.getActivity(context, reqCode, myIntent, flags);
         builder.setContentIntent(contentIntent);
     }
 
@@ -427,20 +423,17 @@ public final class Builder {
 
         int reqCode = random.nextInt();
 
-        PendingIntent toReturn;
+        int flags;
 
         if (SDK_INT >= 34) {
-            toReturn = PendingIntent.getService(
-                    context, reqCode, intent, FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+            flags = FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE;
         } else if (SDK_INT >= 31) {
-            toReturn = PendingIntent.getService(
-                    context, reqCode, intent, FLAG_UPDATE_CURRENT | PendingIntent.FLAG_MUTABLE);
+            flags = FLAG_UPDATE_CURRENT | PendingIntent.FLAG_MUTABLE;
         } else {
-            toReturn = PendingIntent.getService(
-                    context, reqCode, intent, FLAG_UPDATE_CURRENT);
+            flags = FLAG_UPDATE_CURRENT;
         }
 
-        return toReturn;
+        return PendingIntent.getService(context, reqCode, intent, flags);
     }
 
     /**

--- a/src/android/notification/Builder.java
+++ b/src/android/notification/Builder.java
@@ -332,7 +332,7 @@ public final class Builder {
                     context, reqCode, intent, FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
         } else if (SDK_INT >= 31) {
             deleteIntent = PendingIntent.getBroadcast(
-                    context, reqCode, intent, FLAG_UPDATE_CURRENT | 33554432);
+                    context, reqCode, intent, FLAG_UPDATE_CURRENT | PendingIntent.FLAG_MUTABLE);
         } else {
             deleteIntent = PendingIntent.getBroadcast(
                     context, reqCode, intent, FLAG_UPDATE_CURRENT);
@@ -374,7 +374,7 @@ public final class Builder {
                     context, reqCode, myIntent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
         } else if (SDK_INT >= 31) {
             contentIntent = PendingIntent.getActivity(
-                    context, reqCode, myIntent, PendingIntent.FLAG_UPDATE_CURRENT | 33554432);
+                    context, reqCode, myIntent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_MUTABLE);
         } else {
             contentIntent = PendingIntent.getActivity(
                     context, reqCode, myIntent, PendingIntent.FLAG_UPDATE_CURRENT);
@@ -434,7 +434,7 @@ public final class Builder {
                     context, reqCode, intent, FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
         } else if (SDK_INT >= 31) {
             toReturn = PendingIntent.getService(
-                    context, reqCode, intent, FLAG_UPDATE_CURRENT | 33554432);
+                    context, reqCode, intent, FLAG_UPDATE_CURRENT | PendingIntent.FLAG_MUTABLE);
         } else {
             toReturn = PendingIntent.getService(
                     context, reqCode, intent, FLAG_UPDATE_CURRENT);

--- a/src/android/notification/Notification.java
+++ b/src/android/notification/Notification.java
@@ -241,11 +241,13 @@ public final class Notification {
 
             PendingIntent pi;
 
-            if(SDK_INT >= 31){
+            if (SDK_INT >= 34) {
+                pi = PendingIntent.getBroadcast(
+                        context, 0, intent, FLAG_CANCEL_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+            } else if (SDK_INT >= 31) {
                 pi = PendingIntent.getBroadcast(
                         context, 0, intent, FLAG_CANCEL_CURRENT | 33554432);
-            }
-            else{
+            } else {
                 pi = PendingIntent.getBroadcast(
                         context, 0, intent, FLAG_CANCEL_CURRENT);
             }
@@ -365,11 +367,13 @@ public final class Notification {
 
             PendingIntent pi;
 
-            if(SDK_INT >= 31){
+            if (SDK_INT >= 34) {
+                pi = PendingIntent.getBroadcast(
+                        context, 0, intent, PendingIntent.FLAG_IMMUTABLE);
+            } else if (SDK_INT >= 31) {
                 pi = PendingIntent.getBroadcast(
                         context, 0, intent, 33554432);
-            }
-            else{
+            } else {
                 pi = PendingIntent.getBroadcast(
                         context, 0, intent, 0);
             }

--- a/src/android/notification/Notification.java
+++ b/src/android/notification/Notification.java
@@ -246,7 +246,7 @@ public final class Notification {
                         context, 0, intent, FLAG_CANCEL_CURRENT | PendingIntent.FLAG_IMMUTABLE);
             } else if (SDK_INT >= 31) {
                 pi = PendingIntent.getBroadcast(
-                        context, 0, intent, FLAG_CANCEL_CURRENT | 33554432);
+                        context, 0, intent, FLAG_CANCEL_CURRENT | PendingIntent.FLAG_MUTABLE);
             } else {
                 pi = PendingIntent.getBroadcast(
                         context, 0, intent, FLAG_CANCEL_CURRENT);
@@ -372,7 +372,7 @@ public final class Notification {
                         context, 0, intent, PendingIntent.FLAG_IMMUTABLE);
             } else if (SDK_INT >= 31) {
                 pi = PendingIntent.getBroadcast(
-                        context, 0, intent, 33554432);
+                        context, 0, intent, PendingIntent.FLAG_MUTABLE);
             } else {
                 pi = PendingIntent.getBroadcast(
                         context, 0, intent, 0);

--- a/src/android/notification/Notification.java
+++ b/src/android/notification/Notification.java
@@ -239,18 +239,17 @@ public final class Notification {
             if (!date.after(new Date()) && trigger(intent, receiver))
                 continue;
 
-            PendingIntent pi;
+            int flags;
 
             if (SDK_INT >= 34) {
-                pi = PendingIntent.getBroadcast(
-                        context, 0, intent, FLAG_CANCEL_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+                flags = FLAG_CANCEL_CURRENT | PendingIntent.FLAG_IMMUTABLE;
             } else if (SDK_INT >= 31) {
-                pi = PendingIntent.getBroadcast(
-                        context, 0, intent, FLAG_CANCEL_CURRENT | PendingIntent.FLAG_MUTABLE);
+                flags = FLAG_CANCEL_CURRENT | PendingIntent.FLAG_MUTABLE;
             } else {
-                pi = PendingIntent.getBroadcast(
-                        context, 0, intent, FLAG_CANCEL_CURRENT);
+                flags = FLAG_CANCEL_CURRENT;
             }
+
+            PendingIntent pi = PendingIntent.getBroadcast(context, 0, intent, flags);
 
             try {
                 switch (options.getPrio()) {
@@ -364,19 +363,17 @@ public final class Notification {
 
         for (String action : actions) {
             Intent intent = new Intent(action);
-
-            PendingIntent pi;
-
+            
+            int flags = 0;
+            
             if (SDK_INT >= 34) {
-                pi = PendingIntent.getBroadcast(
-                        context, 0, intent, PendingIntent.FLAG_IMMUTABLE);
+                flags = PendingIntent.FLAG_IMMUTABLE;
             } else if (SDK_INT >= 31) {
-                pi = PendingIntent.getBroadcast(
-                        context, 0, intent, PendingIntent.FLAG_MUTABLE);
-            } else {
-                pi = PendingIntent.getBroadcast(
-                        context, 0, intent, 0);
+                flags = PendingIntent.FLAG_MUTABLE;
             }
+
+            PendingIntent pi = PendingIntent.getBroadcast(
+                    context, 0, intent, flags);
 
             if (pi != null) {
                 getAlarmMgr().cancel(pi);


### PR DESCRIPTION
## Description
- This PR makes the pending intents that are being used in the plugin immutable.
- Context:  According to the Android 14 Behaviour Changes page (https://developer.android.com/about/versions/14/behavior-changes-14#safer-intents), for an app targeting Android 14, the system restricts it from sending implicit intents to an internal component if the app creates a mutable pending intent (FLAG_MUTABLE) with an intent that does not specify a component or package. When this happens, an exception is thrown.
- We don't need to use mutable pending intents for the Local Notifications plugins. When Android 12 was released and we needed to specify the mutability of Pending Intents (https://developer.android.com/about/versions/12/behavior-changes-12#pending-intent-mutability), we opted for mutable intents, since this was already the default before Android 12. Even more, Android documentation states that “It is strongly recommended to use FLAG_IMMUTABLE when creating a PendingIntent” (https://developer.android.com/reference/android/app/PendingIntent#FLAG_MUTABLE). 
- This PR also replaces the constant value `33554432` with its corresponding constant `PendingIntent.FLAG_MUTABLE`.  In the past, we had to use the actual values because of MABS 7, which targeted API 30. PendingIntent.FLAG_MUTABLE was introduced in API 31.

## Context
https://outsystemsrd.atlassian.net/browse/RMET-2666

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [X] Android
- [ ] iOS
- [ ] JavaScript

## Tests

- Tested on MABS 10 and MABS 9.
- MABS 10 build: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=3ba36bb449e1d92df641021d23694b516f85d2c7

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [X] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [X] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
