### PR TITLE
RMET-3699 Local Notifications - Fix notification not showing when app is on the foreground on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Please also read the [Upgrade Guide](https://github.com/katzer/cordova-plugin-lo
 
 #### Unreleased
 
+#### Version 0.9.13 (07.10.2024)
+### 07-10-2024
+- Android: Deliver notifications while app is in foreground if `foreground` option is `true`. [RMET-3699](https://outsystemsrd.atlassian.net/browse/RMET-3699)
+
 #### Version 0.9.12 (27.09.2023)
 ### 12-09-2023
 - Android: Make PendingIntents immutable for Android 14 [RMET-2666](https://outsystemsrd.atlassian.net/browse/RMET-2666)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-local-notification",
-  "version": "0.9.12",
+  "version": "0.9.13",
   "description": "Schedules and queries for local notifications",
   "cordova": {
     "id": "cordova-plugin-local-notification",

--- a/plugin.xml
+++ b/plugin.xml
@@ -24,7 +24,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="cordova-plugin-local-notification"
-        version="0.9.12">
+        version="0.9.13">
 
     <name>LocalNotification</name>
 

--- a/src/android/notification/Notification.java
+++ b/src/android/notification/Notification.java
@@ -385,13 +385,11 @@ public final class Notification {
      * Present the local notification to user.
      */
     public void show() {
-
+        // Don't show notification if the application is in foreground and foreground option is false
         boolean showEvenInForeground = getOptions().getDict().optBoolean("foreground", false);
 
-        // Don't show notification if the application is in foreground and foreground option is false
-        if(applicationState == null || (applicationState.equalsIgnoreCase("foreground") && !showEvenInForeground)) {
+        if (applicationState == null || (applicationState.equalsIgnoreCase("foreground") && !showEvenInForeground))
             return;
-        }
 
         if (builder == null) return;
 

--- a/src/android/notification/Notification.java
+++ b/src/android/notification/Notification.java
@@ -385,8 +385,13 @@ public final class Notification {
      * Present the local notification to user.
      */
     public void show() {
-        // Don't show notification if the application is in foreground
-        if(applicationState == null || applicationState.equalsIgnoreCase("foreground")) return;
+
+        boolean showEvenInForeground = getOptions().getDict().optBoolean("foreground", false);
+
+        // Don't show notification if the application is in foreground and foreground option is false
+        if(applicationState == null || (applicationState.equalsIgnoreCase("foreground") && !showEvenInForeground)) {
+            return;
+        }
 
         if (builder == null) return;
 


### PR DESCRIPTION
## Description
- This PR adds a change so that notifications are still delivered if the app is in the foreground but the `foreground` option passed in the `schedule` feature is set to `true`.

## Context
https://outsystemsrd.atlassian.net/browse/RMET-3699

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [X] Android
- [ ] iOS
- [ ] JavaScript

## Tests

- Tested on MABS 10 and MABS 9 in Android 15 (Pixel 7) and Android 12 (Pixel 3XL)
- MABS 10 build: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=671f99ab9c5be94c8acc1a3131536bb4816a87cb
- MABS 9 build: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=a46deb7988c9e66fa9a014402c893c7666d7c87f

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [X] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [X] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
