### PR TITLE
Fix ::: Android ::: Denying notification permission while grating exact alarms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Please also read the [Upgrade Guide](https://github.com/katzer/cordova-plugin-lo
 
 #### Unreleased
 
+### 25-11-2024
+- Android: Fix endless loop of notification permission denial when granting exact alarm permission
+
 #### Version 0.9.13 (07.10.2024)
 ### 07-10-2024
 - Android: Deliver notifications while app is in foreground if `foreground` option is `true`. [RMET-3699](https://outsystemsrd.atlassian.net/browse/RMET-3699)


### PR DESCRIPTION
## Description

An issue was happening in recent Android versions, where consistently denying the Notification permission (until system popup isn't shown), but granting exact alarms, would result in an infinite loop of checking for notification.

The reason for the issue was because the `onResume` that went to request the notification permission again happened before `onRequestPermissionResult`, causing the notification permission request to keep occurring if the user denies the permission.

The fix involved switching the order of exact alarm checking and notification permission - now the plugin first checks if the re is exact alarms scheduling and only after does it request the notification permission - Which is how it is done in health and fitness plugin - https://github.com/OutSystems/cordova-outsystems-healthfitness/blob/main/src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt#L262

Now the behaviour on Android 14 and 15 is the one that happens in Android 13 (exact alarms permission granted by default) - Event is fired, but notification is not shown because permission is denied (Local Notification Sample App shows the notification content as a banner).


## Context

References: https://outsystemsrd.atlassian.net/wiki/spaces/RDME/pages/4426137659/iOS+18+Android+15+Assessment 

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [X] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [X] Android platform
- [ ] iOS platform
- [ ] JavaScript
- [ ] OutSystems

## Tests

Tested granting and denying notification permission and exact alarms scheduling in different android versions - Android 13, Android 15, Android 12.

Sample behaviour for Android 15:
- Before: https://github.com/user-attachments/assets/7034b12c-3fd9-4919-aabf-e8b19d9bdc82
- After:  https://github.com/user-attachments/assets/9a539442-31ce-4e6c-b380-4b106e3580e3




## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [ ] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly