### PR TITLE
RMET-3658 ::: MABS 12 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ ChangeLog
 
 Please also read the [Upgrade Guide](https://github.com/katzer/cordova-plugin-local-notifications/wiki/Upgrade-Guide) for more information.
 
+#### Unreleased
+
+### 26-06-2025
+- iOS: Add hook to add set `handleApplicationNotifications` (https://outsystemsrd.atlassian.net/browse/RMET-3658).
+
 #### Version 0.9.14 (03.12.2024)
 ### 25-11-2024
 - Android: Fix endless loop of notification permission denial when granting exact alarm permission.

--- a/capacitor_hooks/sethandleApplicationNotifications.js
+++ b/capacitor_hooks/sethandleApplicationNotifications.js
@@ -1,0 +1,36 @@
+const fs = require('fs');
+const path = require('path');
+
+const platform = process.env.CAPACITOR_PLATFORM_NAME;
+if (platform != 'ios') {
+    // only needed for iOS - to allow for custom handling of notifications different from what capacitor uses.
+    return;
+}
+const projectDirPath = process.env.CAPACITOR_ROOT_DIR;
+const configPath = path.resolve(projectDirPath, 'ios', 'App', 'App', 'capacitor.config.json');
+console.log('\Local Notifications plugin - running hook before copy for iOS.')
+
+// read the existing config json
+let config = {};
+try {
+  const fileContent = fs.readFileSync(configPath, 'utf-8');
+  config = JSON.parse(fileContent);
+} catch (e) {
+  console.error('\t[ERROR] - Invalid JSON reading and parse - ' + e);
+  process.exit(1);
+}
+
+// merge the new content with the existing json
+const newConfig = {
+  ios: {
+    handleApplicationNotifications: false
+  }
+};
+config.ios = {
+  ...config.ios,
+  ...newConfig.ios
+};
+
+// Write back to config.json
+fs.writeFileSync(configPath, JSON.stringify(config, null, 4));
+console.log('\t[SUCCESS] capacitor.config.json updated successfully.');

--- a/package.json
+++ b/package.json
@@ -51,5 +51,8 @@
   "bugs": {
     "url": "https://github.com/katzer/cordova-plugin-local-notifications/issues"
   },
-  "homepage": "https://github.com/katzer/cordova-plugin-local-notifications#readme"
+  "homepage": "https://github.com/katzer/cordova-plugin-local-notifications#readme",
+  "scripts": {
+    "capacitor:update:after": "node capacitor_hooks/sethandleApplicationNotifications.js"
+  }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR adds a Capacitor hook to set handleApplicationNotifications to false for Capacitor apps, which fixes the issue of notifications not appearing in the iOS Notification Center

## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->
https://outsystemsrd.atlassian.net/browse/RMET-3658
<!--- Why is this change required? What problem does it solve? -->

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [X] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [ ] Android platform
- [X] iOS platform
- [ ] JavaScript
- [ ] OutSystems

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

## Screenshots (if appropriate)
<!--- E.g. before change & after change -->

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [X] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [X] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly