### PR TITLE
RMET-4280 :: Local Notifications Plugin ::: Custom Sounds MABS 11 and 12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ ChangeLog
 
 Please also read the [Upgrade Guide](https://github.com/katzer/cordova-plugin-local-notifications/wiki/Upgrade-Guide) for more information.
 
+#### Version 0.9.16 (05.09.2025)
+### 05-09-2025
+- Fixes an issue where custom notification sounds were not playing. [RMET-4280](https://outsystemsrd.atlassian.net/browse/RMET-4280)
+
 #### Version 0.9.15 (02.07.2025)
 ### 26-06-2025
 - iOS: Add hook to add set `handleApplicationNotifications` (https://outsystemsrd.atlassian.net/browse/RMET-3658).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-local-notification",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "description": "Schedules and queries for local notifications",
   "cordova": {
     "id": "cordova-plugin-local-notification",

--- a/plugin.xml
+++ b/plugin.xml
@@ -24,7 +24,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="cordova-plugin-local-notification"
-        version="0.9.15">
+        version="0.9.16">
 
     <name>LocalNotification</name>
 

--- a/src/android/LocalNotification.java
+++ b/src/android/LocalNotification.java
@@ -170,14 +170,6 @@ public class LocalNotification extends CordovaPlugin {
                     actions(args, command);
                 } else
                 if (action.equals("schedule")) {
-                    for (int i = 0; i < args.length(); i++) {
-                        try {
-                            JSONObject obj = args.getJSONObject(i);
-                            if (!obj.has("channel") || obj.isNull("channel")) {
-                                obj.put("channel", UUID.randomUUID().toString());
-                            }
-                        } catch (JSONException ignored) {}
-                    }
                     schedule(args, command, true);
                 } else
                 if (action.equals("update")) {

--- a/src/android/LocalNotification.java
+++ b/src/android/LocalNotification.java
@@ -170,6 +170,14 @@ public class LocalNotification extends CordovaPlugin {
                     actions(args, command);
                 } else
                 if (action.equals("schedule")) {
+                    for (int i = 0; i < args.length(); i++) {
+                        try {
+                            JSONObject obj = args.getJSONObject(i);
+                            if (!obj.has("channel") || obj.isNull("channel")) {
+                                obj.put("channel", UUID.randomUUID().toString());
+                            }
+                        } catch (JSONException ignored) {}
+                    }
                     schedule(args, command, true);
                 } else
                 if (action.equals("update")) {

--- a/src/android/notification/Builder.java
+++ b/src/android/notification/Builder.java
@@ -118,7 +118,7 @@ public final class Builder {
             return new Notification(context, options);
         }
 
-        Uri sound     = options.getSound();
+        Uri sound     = options.getSoundUri();
         Bundle extras = new Bundle();
 
         extras.putInt(Notification.EXTRA_ID, options.getId());

--- a/src/android/notification/Manager.java
+++ b/src/android/notification/Manager.java
@@ -28,7 +28,10 @@ import android.app.AlarmManager;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.content.Context;
+import android.content.Intent;
 import android.content.SharedPreferences;
+import android.media.AudioAttributes;
+import android.net.Uri;
 import android.os.Build;
 import android.service.notification.StatusBarNotification;
 import androidx.core.app.NotificationManagerCompat;
@@ -109,6 +112,7 @@ public final class Manager {
      */
     public Notification schedule (Request request, Class<?> receiver) {
         Options options    = request.getOptions();
+        createChannel(options);
         Notification toast = new Notification(context, options);
 
         toast.schedule(request, receiver);
@@ -121,19 +125,37 @@ public final class Manager {
      */
     @SuppressLint("WrongConstant")
     private void createDefaultChannel() {
+        createNotificationChannel(
+            CHANNEL_ID,
+            CHANNEL_NAME,
+            IMPORTANCE_DEFAULT,
+            null
+        );
+    }
+
+    private void createChannel(Options options) {
+        createNotificationChannel(
+            options.getChannel(),
+            options.getChannel(),
+            IMPORTANCE_DEFAULT,
+            options.getSound()
+        );
+    }
+
+    private void createNotificationChannel(String id, CharSequence name, int importance, Uri soundUri) {
+        if (SDK_INT < O) return;
         NotificationManager mgr = getNotMgr();
+        NotificationChannel channel = mgr.getNotificationChannel(id);
+        if (channel != null) return;
 
-        if (SDK_INT < O)
-            return;
-
-        NotificationChannel channel = mgr.getNotificationChannel(CHANNEL_ID);
-
-        if (channel != null)
-            return;
-
-        channel = new NotificationChannel(
-                CHANNEL_ID, CHANNEL_NAME, IMPORTANCE_DEFAULT);
-
+        channel = new NotificationChannel(id, name, importance);
+        if (soundUri != null) {
+            AudioAttributes audioAttributes = new AudioAttributes.Builder()
+                    .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                    .setUsage(AudioAttributes.USAGE_NOTIFICATION)
+                    .build();
+            channel.setSound(soundUri, audioAttributes);
+        }
         mgr.createNotificationChannel(channel);
     }
 

--- a/src/android/notification/Manager.java
+++ b/src/android/notification/Manager.java
@@ -31,6 +31,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.media.AudioAttributes;
+import android.media.RingtoneManager;
 import android.net.Uri;
 import android.os.Build;
 import android.service.notification.StatusBarNotification;
@@ -126,19 +127,19 @@ public final class Manager {
     @SuppressLint("WrongConstant")
     private void createDefaultChannel() {
         createNotificationChannel(
-            CHANNEL_ID,
-            CHANNEL_NAME,
-            IMPORTANCE_DEFAULT,
-            null
+                CHANNEL_ID,
+                CHANNEL_NAME,
+                IMPORTANCE_DEFAULT,
+                null
         );
     }
 
     private void createChannel(Options options) {
         createNotificationChannel(
-            options.getChannel(),
-            options.getChannel(),
-            IMPORTANCE_DEFAULT,
-            options.getSound()
+                options.getChannel(),
+                options.getChannel(),
+                IMPORTANCE_DEFAULT,
+                options.getSound()
         );
     }
 
@@ -149,13 +150,14 @@ public final class Manager {
         if (channel != null) return;
 
         channel = new NotificationChannel(id, name, importance);
-        if (soundUri != null) {
-            AudioAttributes audioAttributes = new AudioAttributes.Builder()
-                    .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
-                    .setUsage(AudioAttributes.USAGE_NOTIFICATION)
-                    .build();
-            channel.setSound(soundUri, audioAttributes);
+        AudioAttributes audioAttributes = new AudioAttributes.Builder()
+                .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                .setUsage(AudioAttributes.USAGE_NOTIFICATION)
+                .build();
+        if (soundUri == null || soundUri.toString().isEmpty()) {
+            soundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);
         }
+        channel.setSound(soundUri, audioAttributes);
         mgr.createNotificationChannel(channel);
     }
 

--- a/src/android/notification/Manager.java
+++ b/src/android/notification/Manager.java
@@ -23,18 +23,17 @@
 
 package de.appplant.cordova.plugin.notification;
 
-import android.annotation.SuppressLint;
 import android.app.AlarmManager;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.content.Context;
-import android.content.Intent;
 import android.content.SharedPreferences;
 import android.media.AudioAttributes;
 import android.media.RingtoneManager;
 import android.net.Uri;
 import android.os.Build;
 import android.service.notification.StatusBarNotification;
+
 import androidx.core.app.NotificationManagerCompat;
 
 import org.json.JSONException;
@@ -45,11 +44,10 @@ import java.util.List;
 import java.util.Set;
 
 import de.appplant.cordova.plugin.badge.BadgeImpl;
+import de.appplant.cordova.plugin.notification.util.AssetUtil;
 
 import static android.os.Build.VERSION.SDK_INT;
 import static android.os.Build.VERSION_CODES.M;
-import static android.os.Build.VERSION_CODES.O;
-import static androidx.core.app.NotificationManagerCompat.IMPORTANCE_DEFAULT;
 import static de.appplant.cordova.plugin.notification.Notification.PREF_KEY_ID;
 import static de.appplant.cordova.plugin.notification.Notification.Type.SCHEDULED;
 import static de.appplant.cordova.plugin.notification.Notification.Type.TRIGGERED;
@@ -77,7 +75,6 @@ public final class Manager {
      */
     private Manager(Context context) {
         this.context = context;
-        createDefaultChannel();
     }
 
     /**
@@ -121,44 +118,36 @@ public final class Manager {
         return toast;
     }
 
-    /**
-     * TODO: temporary
-     */
-    @SuppressLint("WrongConstant")
-    private void createDefaultChannel() {
-        createNotificationChannel(
-                CHANNEL_ID,
-                CHANNEL_NAME,
-                IMPORTANCE_DEFAULT,
-                null
-        );
-    }
-
     private void createChannel(Options options) {
-        createNotificationChannel(
-                options.getChannel(),
-                options.getChannel(),
-                IMPORTANCE_DEFAULT,
-                options.getSound()
-        );
-    }
-
-    private void createNotificationChannel(String id, CharSequence name, int importance, Uri soundUri) {
-        if (SDK_INT < O) return;
-        NotificationManager mgr = getNotMgr();
-        NotificationChannel channel = mgr.getNotificationChannel(id);
+        String channelId = options.getChannel();
+        NotificationManager notificationManager = getNotMgr();
+        NotificationChannel channel = notificationManager.getNotificationChannel(channelId);
         if (channel != null) return;
 
-        channel = new NotificationChannel(id, name, importance);
-        AudioAttributes audioAttributes = new AudioAttributes.Builder()
-                .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
-                .setUsage(AudioAttributes.USAGE_NOTIFICATION)
-                .build();
-        if (soundUri == null || soundUri.toString().isEmpty()) {
+        channel = new NotificationChannel(channelId, CHANNEL_NAME, NotificationManager.IMPORTANCE_DEFAULT);
+
+        Uri soundUri = getSoundUri(options.getSound());
+        channel.setSound(
+                soundUri,
+                new AudioAttributes.Builder()
+                        .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                        .setUsage(AudioAttributes.USAGE_NOTIFICATION)
+                        .build()
+        );
+
+        notificationManager.createNotificationChannel(channel);
+    }
+
+    private Uri getSoundUri(String soundPath) {
+        if (soundPath == null || soundPath.isEmpty()) {
+            return RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);
+        }
+
+        Uri soundUri = AssetUtil.getInstance(context).parse(soundPath);
+        if (soundUri == null || soundUri.equals(Uri.EMPTY)) {
             soundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);
         }
-        channel.setSound(soundUri, audioAttributes);
-        mgr.createNotificationChannel(channel);
+        return soundUri;
     }
 
     /**

--- a/src/android/notification/Options.java
+++ b/src/android/notification/Options.java
@@ -215,7 +215,14 @@ public final class Options {
      * The channel id of that notification.
      */
     String getChannel() {
-        return options.optString("channel", Manager.CHANNEL_ID);
+        String channelId = options.optString("channel", null);
+        if (channelId == null || channelId.isEmpty()) {
+            String soundPath = getSound();
+            String soundSuffix = soundPath.isEmpty() ? "" : "." + soundPath.substring(soundPath.lastIndexOf('/') + 1);
+            channelId = Manager.CHANNEL_ID + "." + soundSuffix;
+        }
+
+        return channelId;
     }
 
     /**
@@ -347,8 +354,15 @@ public final class Options {
     /**
      * Sound file path for the local notification.
      */
-    Uri getSound() {
-        return assets.parse(options.optString("sound", null));
+    String getSound() {
+        return options.optString("sound", null);
+    }
+
+    /**
+     * Sound file URI for the local notification.
+     */
+    Uri getSoundUri() {
+        return assets.parse(getSound());
     }
 
     /**

--- a/src/android/notification/util/AssetUtil.java
+++ b/src/android/notification/util/AssetUtil.java
@@ -28,6 +28,7 @@ import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.net.Uri;
+import android.os.Environment;
 import android.os.StrictMode;
 import android.util.Log;
 
@@ -94,7 +95,70 @@ public final class AssetUtil {
             return Uri.parse(path);
         }
 
-        return Uri.EMPTY;
+        return resolveFile(path);
+    }
+
+    public Uri resolveFile(String path) {
+        String[] searchFolders = {"www", "public"};
+        AssetManager assetManager = context.getAssets();
+
+        String base = path.contains(".") ? path.substring(0, path.lastIndexOf(".")) : path;
+        String ext = path.contains(".") ? path.substring(path.lastIndexOf(".") + 1) : "";
+
+        String resolvedPath = "";
+        for (String folder : searchFolders) {
+            try {
+                String[] files = assetManager.list(folder);
+                if (files == null) continue;
+
+                for (String f : files) {
+                    if (f.equalsIgnoreCase(path)) {
+                        resolvedPath = folder + "/" + f;
+                        break;
+                    }
+                }
+
+                String regex = "^" + base + "__.+\\." + ext + "$";
+                for (String f : files) {
+                    if (f.matches("(?i)" + regex)) {
+                        resolvedPath = folder + "/" + f;
+                        break;
+                    }
+                }
+
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+
+        if (resolvedPath.isEmpty()) {
+            return Uri.EMPTY;
+        }
+
+        String fileName = resolvedPath.substring(resolvedPath.lastIndexOf('/') + 1);
+
+        File notificationsDir = new File(
+                Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_NOTIFICATIONS),
+                context.getPackageName()
+        );
+        if (!notificationsDir.exists()) {
+            notificationsDir.mkdirs();
+        }
+
+        File file = new File(notificationsDir, fileName);
+
+        try {
+            if (!file.exists()) {
+                InputStream in = assetManager.open(resolvedPath);
+                FileOutputStream out = new FileOutputStream(file);
+                copyFile(in, out);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            return Uri.EMPTY;
+        }
+
+        return Uri.fromFile(file);
     }
 
     /**

--- a/src/android/notification/util/AssetUtil.java
+++ b/src/android/notification/util/AssetUtil.java
@@ -136,16 +136,7 @@ public final class AssetUtil {
         }
 
         String fileName = resolvedPath.substring(resolvedPath.lastIndexOf('/') + 1);
-
-        File notificationsDir = new File(
-                Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_NOTIFICATIONS),
-                context.getPackageName()
-        );
-        if (!notificationsDir.exists()) {
-            notificationsDir.mkdirs();
-        }
-
-        File file = new File(notificationsDir, fileName);
+        File file = new File(context.getExternalFilesDir(null), fileName);
 
         try {
             if (!file.exists()) {
@@ -158,7 +149,7 @@ public final class AssetUtil {
             return Uri.EMPTY;
         }
 
-        return Uri.fromFile(file);
+        return getUriFromFile(file);
     }
 
     /**

--- a/src/android/notification/util/AssetUtil.java
+++ b/src/android/notification/util/AssetUtil.java
@@ -95,10 +95,10 @@ public final class AssetUtil {
             return Uri.parse(path);
         }
 
-        return resolveFile(path);
+        return resolveAssetFromFilePath(path);
     }
 
-    public Uri resolveFile(String path) {
+    public Uri resolveAssetFromFilePath(String path) {
         String[] searchFolders = {"www", "public"};
         AssetManager assetManager = context.getAssets();
 

--- a/src/ios/APPNotificationOptions.m
+++ b/src/ios/APPNotificationOptions.m
@@ -183,23 +183,33 @@ static NSInteger WEEKDAYS[8] = { 0, 2, 3, 4, 5, 6, 7, 1 };
         NSBundle *mainBundle = [NSBundle mainBundle];
         NSString *resPath = [mainBundle resourcePath];
         NSError *error = nil;
-        NSArray *files = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:[resPath stringByAppendingPathComponent:@"www"] error:&error];
 
-        if (files) {
+        NSArray<NSString *> *searchFolders = @[@"www", @"public"];
+
+        for (NSString *folder in searchFolders) {
+            NSString *folderPath = [resPath stringByAppendingPathComponent:folder];
+            NSArray *files = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:folderPath error:&error];
+            
+            if (!files) {
+                continue;
+            }
+            
             NSString *base = [path stringByDeletingPathExtension];
             NSString *ext = [path pathExtension];
             NSString *exactFile = [NSString stringWithFormat:@"%@.%@", base, ext];
             
             if ([files containsObject:exactFile]) {
-                file = [NSString stringWithFormat:@"www/%@", exactFile];
-            } else {
-                NSString *pattern = [NSString stringWithFormat:@"^%@__.+\\.%@$", base, ext];
-                NSPredicate *predicate = [NSPredicate predicateWithFormat:@"SELF MATCHES[c] %@", pattern];
-                NSArray *matches = [files filteredArrayUsingPredicate:predicate];
-                
-                if (matches.count > 0) {
-                    file = [NSString stringWithFormat:@"www/%@", matches[0]];
-                }
+                file = [NSString stringWithFormat:@"%@/%@", folder, exactFile];
+                break;
+            }
+            
+            NSString *pattern = [NSString stringWithFormat:@"^%@__.+\\.%@$", base, ext];
+            NSPredicate *predicate = [NSPredicate predicateWithFormat:@"SELF MATCHES[c] %@", pattern];
+            NSArray *matches = [files filteredArrayUsingPredicate:predicate];
+            
+            if (matches.count > 0) {
+                file = [NSString stringWithFormat:@"%@/%@", folder, matches[0]];
+                break;
             }
         }
     }

--- a/src/ios/APPNotificationOptions.m
+++ b/src/ios/APPNotificationOptions.m
@@ -177,9 +177,31 @@ static NSInteger WEEKDAYS[8] = { 0, 2, 3, 4, 5, 6, 7, 1 };
 
     if ([path hasPrefix:@"file:/"]) {
         file = [self soundNameForAsset:path];
-    } else
-    if ([path hasPrefix:@"res:"]) {
+    } else if ([path hasPrefix:@"res:"]) {
         file = [self soundNameForResource:path];
+    } else {
+        NSBundle *mainBundle = [NSBundle mainBundle];
+        NSString *resPath = [mainBundle resourcePath];
+        NSError *error = nil;
+        NSArray *files = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:[resPath stringByAppendingPathComponent:@"www"] error:&error];
+
+        if (files) {
+            NSString *base = [path stringByDeletingPathExtension];
+            NSString *ext = [path pathExtension];
+            NSString *exactFile = [NSString stringWithFormat:@"%@.%@", base, ext];
+            
+            if ([files containsObject:exactFile]) {
+                file = [NSString stringWithFormat:@"www/%@", exactFile];
+            } else {
+                NSString *pattern = [NSString stringWithFormat:@"^%@__.+\\.%@$", base, ext];
+                NSPredicate *predicate = [NSPredicate predicateWithFormat:@"SELF MATCHES[c] %@", pattern];
+                NSArray *matches = [files filteredArrayUsingPredicate:predicate];
+                
+                if (matches.count > 0) {
+                    file = [NSString stringWithFormat:@"www/%@", matches[0]];
+                }
+            }
+        }
     }
 
     return [UNNotificationSound soundNamed:file];

--- a/src/ios/APPNotificationOptions.m
+++ b/src/ios/APPNotificationOptions.m
@@ -173,7 +173,7 @@ static NSInteger WEEKDAYS[8] = { 0, 2, 3, 4, 5, 6, 7, 1 };
     }
 
     if (!path.length)
-        return NULL;
+        return [UNNotificationSound defaultSound];
 
     if ([path hasPrefix:@"file:/"]) {
         file = [self soundNameForAsset:path];


### PR DESCRIPTION
This PR introduces the following changes:
- Updates the logic for retrieving the sound file name to ensure compatibility with ODC resource file naming conventions.
- Changes the behavior when no value is defined for sound: previously, no sound was played, but now the default notification sound will be used.
- Updates the sample app to make it easier to test notification sounds.


<img width="270" height="600" alt="Screenshot_20250829_100146" src="https://github.com/user-attachments/assets/d2d9c151-9c69-419a-8029-96e8d9f7f87f" />
<img width="301" height="655" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-28 at 19 10 58" src="https://github.com/user-attachments/assets/503f34b1-4169-468d-a378-38ccbc198e34" />
